### PR TITLE
✨(api) add date/time range filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Implement base view filters: date/times
 - Implement base plugin architecture
 - Bootstrap base backend boilerplate
 - Implement video views endpoint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "${WARREN_BACKEND_SERVER_PORT:-8100}:${WARREN_BACKEND_SERVER_PORT:-8100}"
     command:
       - uvicorn
-      - "warren.api:app"
+      - "core.warren.api:app"
       - "--proxy-headers"
       - "--log-config"
       - "core/logging-config.yaml"

--- a/src/backend/core/pyproject.toml
+++ b/src/backend/core/pyproject.toml
@@ -28,10 +28,11 @@ requires-python = ">=3.7"
 license = {file = "LICENSE.md"}
 keywords = ["Analytics", "xAPI", "LRS", "LTI"]
 dependencies = [
+    "arrow==1.2.2",
     "elasticsearch[async]==8.6.2",
-    "fastapi==0.92.0",
+    "fastapi==0.95.2",
     "importlib-metadata==6.6.0",
-    "pydantic[dotenv]==1.10.5",
+    "pydantic[dotenv]==1.10.8",
     "rfc3987==1.3.8",
     "sentry-sdk[fastapi]==1.15.0",
     "uvicorn[standard]==0.20.0",

--- a/src/backend/core/warren/conf.py
+++ b/src/backend/core/warren/conf.py
@@ -1,6 +1,7 @@
 """Warren configuration."""
 
 import io
+from datetime import timedelta
 from pathlib import Path
 from typing import List, Union
 
@@ -27,6 +28,10 @@ class Settings(BaseSettings):
     SERVER_PROTOCOL: str = "http"
     SERVER_HOST: str = "localhost"
     SERVER_PORT: int = 8100
+
+    # API configuration
+    MAX_DATETIMERANGE_SPAN: timedelta = timedelta(days=365)  # 1 year shift from since
+    DEFAULT_DATETIMERANGE_SPAN: timedelta = timedelta(days=7)  # 7 days shift from until
 
     # Securiry
     ALLOWED_HOSTS: List[str] = [

--- a/src/backend/core/warren/fields.py
+++ b/src/backend/core/warren/fields.py
@@ -1,6 +1,51 @@
 """Warren model fields."""
 
+import datetime
+
+import arrow
 import rfc3987
+
+
+class Date:
+    """Arrow-parser-based date field."""
+
+    @classmethod
+    def __get_validators__(cls):
+        """Yields default class validator."""
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value) -> datetime.date:
+        """Parse arrow-compatible date string."""
+        if isinstance(value, datetime.date):
+            return value
+        if isinstance(value, arrow.Arrow):
+            return value.date()
+        try:
+            return arrow.get(value).date()
+        except arrow.ParserError as err:
+            raise ValueError("Invalid input date") from err
+
+
+class Datetime:
+    """Arrow-parser-based date/time field."""
+
+    @classmethod
+    def __get_validators__(cls):
+        """Yields default class validator."""
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value) -> datetime.datetime:
+        """Parse arrow-compatible date/time string."""
+        if isinstance(value, datetime.datetime):
+            return value
+        if isinstance(value, arrow.Arrow):
+            return value.datetime
+        try:
+            return arrow.get(value).datetime
+        except arrow.ParserError as err:
+            raise ValueError("Invalid input date/time") from err
 
 
 class IRI(str):

--- a/src/backend/core/warren/filters.py
+++ b/src/backend/core/warren/filters.py
@@ -1,0 +1,78 @@
+"""Warren API filters."""
+
+import arrow
+from fastapi import HTTPException
+from pydantic import BaseModel, ValidationError, root_validator
+
+from .conf import settings
+from .fields import Datetime
+
+
+class DatetimeRange(BaseModel):
+    """A date/time range."""
+
+    since: Datetime = None
+    until: Datetime = None
+
+    class Config:
+        """Datetime range model configuration."""
+
+        arbitrary_types_allowed = True
+
+    @root_validator(pre=True)
+    @classmethod
+    def set_datetime_range_defaults(cls, values):
+        """Set date/time range defaults to the last DEFAULT_DATETIMERANGE_SPAN days."""
+        now = arrow.utcnow()
+        since, until = map(values.get, ["since", "until"])
+        if until is None:
+            until = Datetime.validate(now)
+        else:
+            until = Datetime.validate(until)
+        values["until"] = until
+        if since is None:
+            values["since"] = Datetime.validate(
+                until - settings.DEFAULT_DATETIMERANGE_SPAN
+            )
+        return values
+
+    @root_validator
+    @classmethod
+    def check_range_consistency(cls, values):
+        """Check date/time range consistency."""
+        if values.get("since") > values.get("until"):
+            raise ValueError("Invalid date range: since cannot be after until")
+        return values
+
+
+class BaseQueryFilters(DatetimeRange):
+    """Common query filters that every API endpoint should implement."""
+
+    @root_validator
+    @classmethod
+    def check_datetime_range_consistency(cls, values):
+        """Check date/time range consistency.
+
+        A wrapper for the DatetimeRange.check_range_consistency root validator
+        that raises an HTTPException instead of a ValueError since FastAPI does
+        not support root validators for query models dependency injections.
+
+        See: https://github.com/tiangolo/fastapi/discussions/9071
+
+        """
+        try:
+            DatetimeRange.parse_obj(values)
+        except ValidationError as err:
+            for error in err.errors():
+                error["loc"] = ["query"] + list(error["loc"])
+            raise HTTPException(422, detail=err.errors()) from err
+        return values
+
+    @root_validator
+    @classmethod
+    def check_datetime_range_span(cls, values):
+        """Check that date/time range is not too greedy."""
+        since, until = map(values.get, ["since", "until"])
+        if since + settings.MAX_DATETIMERANGE_SPAN < until:
+            raise HTTPException(422, detail="Date/time range is too greedy.")
+        return values

--- a/src/backend/core/warren/tests/test_fields.py
+++ b/src/backend/core/warren/tests/test_fields.py
@@ -1,0 +1,65 @@
+"""Tests for pydantic model fields."""
+
+import datetime
+
+import arrow
+import pytest
+from pydantic import BaseModel
+
+from warren.fields import Date, Datetime
+
+
+@pytest.mark.parametrize(
+    "date",
+    ["2023-12-01", "20231201", arrow.get("2023-12-01"), datetime.date(2023, 12, 1)],
+)
+def test_date_field(date):
+    """Test the Date warren field."""
+
+    # pylint: disable=missing-class-docstring
+    class MyModel(BaseModel):
+        saved_at: Date
+
+    my_model = MyModel(saved_at=date)
+    assert my_model.saved_at.year == 2023
+    assert my_model.saved_at.month == 12
+    assert my_model.saved_at.day == 1
+
+
+def test_date_field_with_invalid_inputs():
+    """Test the Date warren field with invalud inputs."""
+
+    # pylint: disable=missing-class-docstring
+    class MyModel(BaseModel):
+        saved_at: Date
+
+    with pytest.raises(ValueError, match="Invalid input date"):
+        MyModel(saved_at="foo")
+
+
+@pytest.mark.parametrize(
+    "date_time",
+    ["2023-12-01", "20231201", arrow.get("2023-12-01"), datetime.datetime(2023, 12, 1)],
+)
+def test_datetime_field(date_time):
+    """Test the Datetime warren field."""
+
+    # pylint: disable=missing-class-docstring
+    class MyModel(BaseModel):
+        saved_at: Datetime
+
+    my_model = MyModel(saved_at=date_time)
+    assert my_model.saved_at.year == 2023
+    assert my_model.saved_at.month == 12
+    assert my_model.saved_at.day == 1
+
+
+def test_datetime_field_with_invalid_inputs():
+    """Test  the Datetime warren field with invalud inputs."""
+
+    # pylint: disable=missing-class-docstring
+    class MyModel(BaseModel):
+        saved_at: Datetime
+
+    with pytest.raises(ValueError, match="Invalid input date/time"):
+        MyModel(saved_at="foo")

--- a/src/backend/core/warren/tests/test_filters.py
+++ b/src/backend/core/warren/tests/test_filters.py
@@ -1,0 +1,88 @@
+"""Tests for the core API filters."""
+
+import datetime
+
+import arrow
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from warren.conf import settings
+from warren.filters import BaseQueryFilters, DatetimeRange
+
+
+# pylint: disable=no-member
+def test_datetime_range_model():
+    """Test the DatetimeRange model."""
+
+    # Arrow supports various input string formats, let's just test one
+    period = DatetimeRange(since="2023-01-01 10:42", until="2023-01-02 12:22")
+
+    assert period.since.year == period.until.year == 2023
+    assert period.since.month == period.until.month == 1
+    assert period.since.day == 1
+    assert period.since.hour == 10
+    assert period.since.minute == 42
+    assert period.until.day == 2
+    assert period.until.hour == 12
+    assert period.until.minute == 22
+
+    # It also supports Arrow instances
+    period = DatetimeRange(since=arrow.get("2023-01-01"), until=arrow.get("2023-01-02"))
+    assert period.since.year == period.until.year == 2023
+    assert period.since.month == period.until.month == 1
+    assert period.since.day == 1
+    assert period.until.day == 2
+    assert period.since.hour == period.until.hour == 0
+    assert period.since.minute == period.until.minute == 0
+
+    with pytest.raises(
+        ValidationError,
+        match="since\\n  Invalid input date\\/time \\(type=value_error\\)",
+    ):
+        DatetimeRange(since="2023-01-ee", until="2023-01-01")
+
+    with pytest.raises(
+        ValidationError, match="Invalid date range: since cannot be after until"
+    ):
+        DatetimeRange(since="2023-01-02", until="2023-01-01")
+
+
+# pylint: disable=no-member
+def test_datetime_range_model_defaults(monkeypatch):
+    """Test the DatetimeRange model defaults."""
+
+    now = arrow.utcnow()
+    monkeypatch.setattr(arrow, "utcnow", lambda: now)
+
+    # Since and until fields are not required. We should not raise exceptions
+    # if not all fields are provided.
+    period = DatetimeRange()
+    assert period.since == now.shift(days=-7)
+    assert period.until == now
+
+    period = DatetimeRange(since=now.shift(months=-6))
+    assert period.until == now
+
+    period = DatetimeRange(until="2023.01.02")
+    assert period.since == period.until - datetime.timedelta(days=7)
+
+
+def test_base_query_filters_model():
+    """Test the BaseQueryFilters model."""
+
+    filters = BaseQueryFilters(since="2023-01-11", until="2023-02-11")
+    assert filters.since == arrow.get("2023-01-11")
+    assert filters.until == arrow.get("2023-02-11")
+
+    # Date/time range consistency
+    with pytest.raises(HTTPException, match="422"):
+        BaseQueryFilters(since="2023-01-11", until="2023-01-10")
+
+    # Check Date/time range max span
+    now = arrow.utcnow()
+    since = now
+    until = now + settings.MAX_DATETIMERANGE_SPAN
+    filters = BaseQueryFilters(since=since, until=until)
+    with pytest.raises(HTTPException, match="422"):
+        BaseQueryFilters(since=since, until=until.shift(days=1))

--- a/src/backend/plugins/video/tests/test_api.py
+++ b/src/backend/plugins/video/tests/test_api.py
@@ -3,9 +3,9 @@
 import arrow
 import pytest
 from warren_video.api import VideoDayViews, VideoViews
+from warren_video.factories import VideoPlayedFactory
 
 from warren.conf import settings
-from warren.factories.video import VideoPlayedFactory
 from warren.filters import DatetimeRange
 
 

--- a/src/backend/plugins/video/warren_video/factories.py
+++ b/src/backend/plugins/video/warren_video/factories.py
@@ -2,7 +2,7 @@
 
 from ralph.models.xapi.video.statements import VideoPlayed
 
-from .base import BaseXapiStatementFactory
+from warren.factories.base import BaseXapiStatementFactory
 
 
 class VideoPlayedFactory(BaseXapiStatementFactory):


### PR DESCRIPTION
## Purpose

As we manipulate time-based data, we need a way to filter queries using date/time ranges. Those filters should be generic and should be injected as a dependency for every route corresponding to an indicator.

## Proposal

- [x] integrate date/time filter to the daily video views indicator
- [x] fix broken tests (due to new filters integration)
- [x] battle test filters

One should note that:

1. default time range corresponds to the last seven days,
2. the time range cannot be greater than the API_MAX_TIMESPAN setting.
