### PR TITLE
🏗️ (project) add Ralph LRS to the development stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,8 +197,6 @@ jobs:
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
-        environment:
-          RALPH_APP_DIR: ~/fun/.ralph
       - image: elasticsearch:8.6.2
         auth:
           username: $DOCKER_HUB_USER

--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,8 @@
 # Define development environment variables here.
 WARREN_ES_HOSTS=http://elasticsearch:9200
 WARREN_ES_INDEX=statements
+RALPH_BACKENDS__DATABASE__ES__HOSTS=http://elasticsearch:9200
+RALPH_BACKENDS__DATABASE__ES__INDEX=statements
+
+RALPH_RUNSERVER_PORT=8200
+RALPH_AUTH_FILE=/app/.ralph/auth.json

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ venv.bak/
 # Project
 bin/patch_statements_date.py
 data
+.ralph/auth.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - ./src/backend:/app
       - ./bin/patch_statements_date.py:/opt/src/patch_statements_date.py
     depends_on:
-      - elasticsearch
+      - ralph
 
   frontend:
     build:
@@ -55,6 +55,25 @@ services:
       - backend
 
   # -- backends
+  ralph:
+    image: fundocker/ralph
+    user: ${DOCKER_USER:-1000}
+    env_file:
+      - .env
+    ports:
+      - "${RALPH_RUNSERVER_PORT:-8200}:${RALPH_RUNSERVER_PORT:-8200}"
+    command:
+      - ralph
+      - "-v"
+      - DEBUG
+      - runserver
+      - "-b"
+      - "es"
+    volumes:
+      - .:/app
+    depends_on:
+      - elasticsearch
+
   elasticsearch:
     image: elasticsearch:8.6.2
     environment:
@@ -65,8 +84,5 @@ services:
     mem_limit: 2g
 
   # -- tools
-  ralph:
-    image: fundocker/ralph
-
   dockerize:
     image: jwilder/dockerize


### PR DESCRIPTION
## Purpose

We want warren to query ralph LRS as opposed to directly query the database backend (elasticsearch).
To do so, having ralph in the docker compose would be easier than running both projects locally.

## Proposal
Integrate fundocker/ralph into the docker-compose.yml

- [x] create the docker compose ralph service
- [x] configure the ralph service so that it queries the elastic setup in the elasticsearch service 
