### PR TITLE
🐛(api) make custom pydantic types Date and Datetime compatible with JSON schema

### DIFF
--- a/src/backend/core/warren/fields.py
+++ b/src/backend/core/warren/fields.py
@@ -26,6 +26,11 @@ class Date:
         except arrow.ParserError as err:
             raise ValueError("Invalid input date") from err
 
+    @classmethod
+    def __modify_schema__(cls, field_schema):
+        """Make field JSON schema serializable."""
+        field_schema.update(type="string", example="2023-01-01")
+
 
 class Datetime:
     """Arrow-parser-based date/time field."""
@@ -46,6 +51,11 @@ class Datetime:
             return arrow.get(value).datetime
         except arrow.ParserError as err:
             raise ValueError("Invalid input date/time") from err
+
+    @classmethod
+    def __modify_schema__(cls, field_schema):
+        """Make field JSON schema serializable."""
+        field_schema.update(type="string", example="2023-01-01")
 
 
 class IRI(str):


### PR DESCRIPTION
Fix the swagger v1 docs generating an error (/api/v1/docs). The Date and Datetime fields were not declarable with JSON schema

## Purpose

Fix the Date and Datetime pydantic models so that they can be picked up by JSON schema

## Proposal
Manually declare conversion to dict for Date and Datetime

- [x] Make Date and Datetime custom pydantic types compatible with JSON schema
