### PR TITLE
🔧(project) remove python-dev from backend Docker image

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -22,8 +22,7 @@ RUN apt-get update && \
         build-essential \
         gcc \
         libc6-dev \
-        libffi-dev \
-        python-dev && \
+        libffi-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install ./core ./plugins/*


### PR DESCRIPTION
## Purpose

`python-dev` has been removed from apt repo and is making the build fail.

## Proposal

The package isn't used in Warren so it does not need to be installed anymore.

