### PR TITLE
✨(backend) implement addition operation for VideoDayViews class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,6 @@ and this project adheres to
 - Bootstrap base backend boilerplate
 - Implement video views endpoint
 - Bootstrap base frontend boilerplate using turborepo
+- Add addition on `VideoDayViews` class, prevent potential issue on `VideoViews`
 
 [unreleased]: https://github.com/openfun/warren

--- a/src/backend/plugins/video/tests/test_api.py
+++ b/src/backend/plugins/video/tests/test_api.py
@@ -171,3 +171,37 @@ def test_video_views_addition_between_two(views_one, views_two):
     assert video_two + video_one == views_one + views_two
     assert video_one.views == views_one
     assert video_two.views == views_two
+
+
+@pytest.mark.parametrize("video_views", [1, -10, 10, 0])
+def test_video_total_single_daily_video(video_views):
+    """Test the total of a single-video list."""
+
+    video = VideoDayViews(day="2023-02-01", views=video_views)
+    views = VideoViews(daily_views=[video])
+
+    assert views.total == video_views
+
+
+@pytest.mark.parametrize("views_one", [1, -10, 10, 0])
+@pytest.mark.parametrize("views_two", [1, -10, 10, 0])
+def test_video_total_multiple_daily_videos(views_one, views_two):
+    """Test the total of a multiple-video list."""
+
+    video_one = VideoDayViews(day="2023-02-01", views=views_one)
+    video_two = VideoDayViews(day="2023-02-02", views=views_two)
+
+    views = VideoViews(daily_views=[video_one, video_two])
+
+    assert views.total == views_one + views_two
+
+
+def test_video_total_setter_error():
+    """Test setting total property's value."""
+
+    video = VideoDayViews(day="2023-02-01", views=10)
+    views = VideoViews(daily_views=[video])
+
+    with pytest.raises(ValueError) as excinfo:
+        views.total = 100
+    assert "total" in str(excinfo.value)

--- a/src/backend/plugins/video/tests/test_api.py
+++ b/src/backend/plugins/video/tests/test_api.py
@@ -136,3 +136,38 @@ async def test_views_backend_query(es_client, http_client):
         VideoDayViews(day="2023-02-09", views=0),
         VideoDayViews(day="2023-02-10", views=0),
     ]
+
+
+@pytest.mark.parametrize("initial_value", [1, -10, 10, 0, 1.0])
+@pytest.mark.parametrize("number", [1, -10, 10, 0, 1.0])
+def test_video_views_addition_with_a_number(number, initial_value):
+    """Test the addition between VideoDayViews and a number."""
+
+    views = VideoDayViews(day="2023-02-01", views=initial_value)
+
+    # Test __add__
+    assert views + number == initial_value + number
+    assert views.views == initial_value
+
+    # Test __radd__
+    assert number + views == initial_value + number
+    assert views.views == initial_value
+
+
+@pytest.mark.parametrize("views_one", [1, -10, 10, 0])
+@pytest.mark.parametrize("views_two", [1, -10, 10, 0])
+def test_video_views_addition_between_two(views_one, views_two):
+    """Test the addition between two VideoDayViews."""
+
+    video_one = VideoDayViews(day="2023-02-01", views=views_one)
+    video_two = VideoDayViews(day="2023-02-02", views=views_two)
+
+    # Test __add__
+    assert video_one + video_two == views_one + views_two
+    assert video_one.views == views_one
+    assert video_two.views == views_two
+
+    # Test __radd__
+    assert video_two + video_one == views_one + views_two
+    assert video_one.views == views_one
+    assert video_two.views == views_two

--- a/src/backend/plugins/video/warren_video/api.py
+++ b/src/backend/plugins/video/warren_video/api.py
@@ -35,8 +35,12 @@ class VideoDayViews(BaseModel):
 class VideoViews(BaseModel):
     """Model to represent video views."""
 
-    total: int
     daily_views: List[VideoDayViews]
+
+    @property
+    def total(self):
+        """Total of daily views."""
+        return sum(self.daily_views)
 
 
 @router.get("/{video_id:path}/views")

--- a/src/backend/plugins/video/warren_video/api.py
+++ b/src/backend/plugins/video/warren_video/api.py
@@ -23,6 +23,14 @@ class VideoDayViews(BaseModel):
     day: Date
     views: int = 0
 
+    def __add__(self, other):
+        """Emulates addition, left member."""
+        return self.views + other
+
+    def __radd__(self, other):
+        """Emulates addition, right member."""
+        return self.views + other
+
 
 class VideoViews(BaseModel):
     """Model to represent video views."""


### PR DESCRIPTION
## Purpose

Add new functionnalities on `VideoDayViews` class and prevent potentiel issue on `VideoViews`.

## Proposal

Added `__add__` and `__radd__` methods to `VideoDayViews` class for left-sided or right-sided addition operations

In the `VideoViews` class, there was a potential issue where the total and daily_views attributes could become desynchronized, causing bugs. To address this, `total` is now a read-only property that is dynamically computed based on the `daily_views` value.

Minor improvement: The current implementation recomputes the `total` property every time its value is accessed, which may impact performance. To mitigate this, I propose using the `@cached_property` decorator, which computes the value only once. However, it is important to ensure that the cached value of `total` is updated whenever `daily_views` changes. I would address this improvement in a next PR.
