### PR TITLE
Backend add git pre commit hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,7 @@
 SHELL := /bin/bash
 
 # -- Docker
-# Get the current user ID to use for docker run and docker exec commands
-DOCKER_UID           = $(shell id -u)
-DOCKER_GID           = $(shell id -g)
-DOCKER_USER          = $(DOCKER_UID):$(DOCKER_GID)
-COMPOSE              = DOCKER_USER=$(DOCKER_USER) docker compose
+COMPOSE              = bin/compose
 COMPOSE_RUN          = $(COMPOSE) run --rm --no-deps
 COMPOSE_RUN_API      = $(COMPOSE_RUN) api
 COMPOSE_RUN_FRONTEND = $(COMPOSE_RUN) frontend
@@ -59,6 +55,14 @@ default: help
 
 .env:
 	cp .env.dist .env
+
+.git/hooks/pre-commit:
+	ln -sf ../../bin/git-hook-pre-commit .git/hooks/pre-commit
+
+git-hook-pre-commit:  ## Install git pre-commit hook
+git-hook-pre-commit: .git/hooks/pre-commit
+	@echo "Git pre-commit hook linked"
+.PHONY: git-hook-pre-commit
 
 .ralph/auth.json:
 	@$(COMPOSE_RUN) ralph ralph \

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ We try to raise our code quality standards and expect contributors to follow
 the recommandations from our
 [handbook](https://handbook.openfun.fr).
 
+You can ensure your code is compliant by running the following commands:
+
+- `make lint` to run the linters
+- `make test` to run the tests
+
+Note that we also provide a git pre-commit hook to ease your life:
+```
+make git-hook-pre-commit
+```
+
 ## License
 
 This work is released under the MIT License (see [LICENSE](./LICENSE.md)).

--- a/bin/compose
+++ b/bin/compose
@@ -3,4 +3,11 @@
 declare DOCKER_USER
 DOCKER_USER="$(id -u):$(id -g)"
 
-DOCKER_USER=${DOCKER_USER} docker compose "$@"
+extra_args=()
+# Prevent 'the input device is not a TTY' error from `docker compose run` by disabling TTY when standard output is not a TTY
+if [[ "$1" == run && "$(tty 2>/dev/null)" == "not a tty" ]]; then
+  extra_args=(run --no-TTY)
+  shift
+fi
+
+DOCKER_USER=${DOCKER_USER} docker compose "${extra_args[@]}" "$@"

--- a/bin/git-hook-pre-commit
+++ b/bin/git-hook-pre-commit
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Git pre-commit hook to lint the project code before committing.
+# This script is called by "git commit" with no arguments. The hook should
+# exit with a non-zero status and display an appropriate message if it
+# wants to stop the commit.
+
+# Usage:
+# This hook can be enabled by running `make git-hook-pre-commit`.
+
+# Get the commit reference against which we are comparing changes.
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+  against=HEAD
+else
+  # Initial commit: diff against an empty tree object
+  against=$(git hash-object -t tree /dev/null)
+fi
+
+# Check for trailing whitespace errors.
+echo "pre-commit hook: checking trailing whitespace…"
+git diff-index --check --cached "$against" --
+
+# Run the necessary commands to check modified code sources.
+if git diff --cached --name-only | grep -q 'src/api'; then
+  make lint-api
+fi
+if git diff --cached --name-only | grep -q 'src/app'; then
+  make lint-app
+fi
+if git diff --cached --name-only | grep -q 'src/frontend'; then
+  make lint-frontend
+fi


### PR DESCRIPTION
## Purpose
Add a git pre commit hook so that some ci checks can be run locally on every commit

## Proposal
Create a bin/git-hook-pre-commit that is linked to the .git/hooks folder when running `make bootstrap`
and that executes black and ruff on every commit

Description...

- [x] setup the git pre commit hook during `make bootstrap`
- [x] check for trailing whitespace
- [x] run black in the hook
- [x] run ruff in the hook

closes #26 
