### PR TITLE
✨️(backend) add 2 endpoint parameters

### DIFF
--- a/src/backend/core/warren/base_indicator.py
+++ b/src/backend/core/warren/base_indicator.py
@@ -1,8 +1,55 @@
 """Abstract class defining the interface for an indicator."""
+import hashlib
 from abc import ABC, abstractmethod
 from typing import List
 
+import pandas as pd
 from ralph.backends.http.lrs import LRSQuery
+
+from warren.conf import settings
+
+
+def parse_raw_statements(raw_statements) -> pd.DataFrame:
+    """Parse LRS statements, explode the columns, and add a `date` column."""
+    flattened = pd.json_normalize(raw_statements)
+    # Disable chained assignment warning to make the transformation inplace
+    pd.options.mode.chained_assignment = None
+    # Transform timestamp column into a date with day (YYYY-MM-DD)
+    flattened.loc[:, "date"] = pd.to_datetime(flattened.loc[:, "timestamp"]).dt.date
+    return flattened
+
+
+def add_actor_unique_id(statements: pd.DataFrame) -> pd.DataFrame:
+    """Add a `actor.uuid` column that uniquely identifies the agent.
+
+    Depending on the xAPI statements, the actor can be identified in 4 different ways :
+    https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#details-4. This
+    function handles the 4 cases and creates a `unique_actor_id` column that
+    can be used later without worrying about the 4 IFIs.
+    """
+    xapi_actor_identifier_columns = settings.XAPI_ACTOR_IDENTIFIER_PATHS.intersection(
+        set(statements.columns)
+    )
+
+    if len(xapi_actor_identifier_columns) == 0:
+        raise ValueError(
+            "There is no way of identifying the agent in submitted statements."
+        )
+    statements["actor.uuid"] = statements.apply(
+        lambda row: hashlib.sha256(
+            "-".join(str(row[col]) for col in xapi_actor_identifier_columns).encode()
+        ).hexdigest(),
+        axis=1,
+    )
+
+    return statements
+
+
+def pre_process_statements(statements: List) -> pd.DataFrame:
+    """Denormalize raw statements, and add utility columns."""
+    parsed = parse_raw_statements(statements)
+    with_unique_id = add_actor_unique_id(parsed)
+    return with_unique_id
 
 
 class BaseIndicator(ABC):

--- a/src/backend/core/warren/conf.py
+++ b/src/backend/core/warren/conf.py
@@ -32,6 +32,13 @@ class Settings(BaseSettings):
     MAX_DATETIMERANGE_SPAN: timedelta = timedelta(days=365)  # 1 year shift from since
     DEFAULT_DATETIMERANGE_SPAN: timedelta = timedelta(days=7)  # 7 days shift from until
     DATE_FORMAT: str = "YYYY-MM-DD"
+    XAPI_ACTOR_IDENTIFIER_PATHS = {
+        "actor.account.name",
+        "actor.account.homePage",
+        "actor.mbox",
+        "actor.mbox_sha1sum",
+        "actor.openid",
+    }
 
     # Security
     ALLOWED_HOSTS: List[str] = [

--- a/src/backend/core/warren/models.py
+++ b/src/backend/core/warren/models.py
@@ -1,6 +1,6 @@
 """Warren's core models."""
 from enum import Enum
-from typing import Generic, TypeVar
+from typing import Any, Dict, Generic, TypeVar
 
 from pydantic.main import BaseModel
 
@@ -26,3 +26,6 @@ class Response(BaseModel, Generic[T]):
 
     status: StatusEnum
     content: T
+
+
+XAPI_STATEMENT = Dict[str, Any]

--- a/src/backend/plugins/video/tests/test_api.py
+++ b/src/backend/plugins/video/tests/test_api.py
@@ -142,7 +142,7 @@ async def test_views_backend_query(
     video_views = (Response[VideoViews]).parse_obj(response.json()).content
 
     assert video_views["total_views"] == 1
-    assert video_views["views_count_by_date"][0] == {
+    assert video_views["count_by_date"][0] == {
         "date": datetime.utcnow().date().isoformat(),
         "count": 1,
     }

--- a/src/backend/plugins/video/warren_video/api.py
+++ b/src/backend/plugins/video/warren_video/api.py
@@ -7,7 +7,7 @@ from warren.backends import lrs_client
 from warren.fields import IRI
 from warren.filters import BaseQueryFilters, DatetimeRange
 from warren.models import Error, Response, StatusEnum
-from warren_video.indicators import DailyVideoViews
+from warren_video.indicators import DailyCompletedVideoViews, DailyVideoViews
 from warren_video.models import VideoViews
 
 router = APIRouter(
@@ -19,14 +19,23 @@ logger = logging.getLogger(__name__)
 
 @router.get("/{video_uuid:path}/views")
 async def views(
-    video_uuid: IRI, filters: Annotated[BaseQueryFilters, Depends()]
+    video_uuid: IRI,
+    filters: Annotated[BaseQueryFilters, Depends()],
+    complete: bool = False,
+    unique: bool = False,
 ) -> Response[VideoViews]:
     """Number of views for `video_uuid` in the `since` -> `until` date range."""
-    indicator = DailyVideoViews(
-        client=lrs_client,
-        video_uuid=video_uuid,
-        date_range=DatetimeRange(since=filters.since, until=filters.until),
-    )
+    indicator_kwargs = {
+        "client": lrs_client,
+        "video_uuid": video_uuid,
+        "date_range": DatetimeRange(since=filters.since, until=filters.until),
+        "is_unique": unique,
+    }
+
+    if complete:
+        indicator = DailyCompletedVideoViews(**indicator_kwargs)
+    else:
+        indicator = DailyVideoViews(**indicator_kwargs)
     try:
         response = Response[VideoViews](
             status=StatusEnum.SUCCESS, content=indicator.compute()

--- a/src/backend/plugins/video/warren_video/indicators.py
+++ b/src/backend/plugins/video/warren_video/indicators.py
@@ -2,12 +2,13 @@
 
 from typing import List
 
-import pandas as pd
 from ralph.backends.http.lrs import BaseHTTP, LRSQuery
 from ralph.models.xapi.concepts.constants.video import RESULT_EXTENSION_TIME
+from ralph.models.xapi.concepts.verbs.scorm_profile import CompletedVerb
 from ralph.models.xapi.concepts.verbs.video import PlayedVerb
-from warren.base_indicator import BaseIndicator
+from warren.base_indicator import BaseIndicator, pre_process_statements
 from warren.filters import DatetimeRange
+from warren.models import XAPI_STATEMENT
 from warren_video.conf import settings as video_plugin_settings
 from warren_video.models import VideoViews
 
@@ -19,19 +20,28 @@ class DailyVideoViews(BaseIndicator):
     a date range, the total number of views, and the number of views per day.
     """
 
-    def __init__(self, client: BaseHTTP, video_uuid: str, date_range: DatetimeRange):
+    def __init__(
+        self,
+        client: BaseHTTP,
+        video_uuid: str,
+        date_range: DatetimeRange,
+        is_unique: bool,
+    ):
         """Instantiate the indicator with its parameters.
 
         Args:
-            client: The LRS backend from which the query is to be issued
+            client: The LRS backend to query
             video_uuid: The UUID of the video on which to compute the metric
             date_range: The date range on which to compute the indicator. It has
                 2 fields, `since` and `until` which are dates or timestamps that must be
                 in ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss.SSSZ")
+            is_unique: If true, multiple views by the same actor are counted as
+                one
         """
         self.client = client
         self.video_uuid = video_uuid
         self.date_range = date_range
+        self.is_unique = is_unique
 
     def get_lrs_query(self) -> LRSQuery:
         """Returns the LRS query for fetching required statements."""
@@ -44,7 +54,7 @@ class DailyVideoViews(BaseIndicator):
             }
         )
 
-    def fetch_statements(self) -> List:
+    def fetch_statements(self) -> List[XAPI_STATEMENT]:
         """Executes the LRS query to obtain statements required for this indicator."""
         return list(
             self.client.read(
@@ -53,7 +63,7 @@ class DailyVideoViews(BaseIndicator):
         )
 
     def compute(self) -> VideoViews:
-        """Fetches statements and domputes the current indicator.
+        """Fetches statements and computes the current indicator.
 
         Fetches the statements from the LRS, filters and aggregates them to return the
         number of video views per day.
@@ -62,26 +72,24 @@ class DailyVideoViews(BaseIndicator):
         raw_statements = self.fetch_statements()
         if not raw_statements:
             return indicator
-        flattened = pd.json_normalize(raw_statements)
+        flattened = pre_process_statements(raw_statements)
 
-        # Filter out video played events before configured time threshold
+        # Filter out video played events before the configured time threshold
         def filter_view_duration(row):
             return (
                 row[f"result.extensions.{RESULT_EXTENSION_TIME}"]
                 >= video_plugin_settings.VIEWS_COUNT_TIME_THRESHOLD
             )
 
-        # Apply the filtering function to each row and update the DataFrame in place
+        # Apply the filtering function to each row
         filtered_view_duration = flattened[
             flattened.apply(filter_view_duration, axis=1)
         ]
 
-        # Disable chained assignment warning, as following Pandas advice doesn't work
-        pd.options.mode.chained_assignment = None
-        # Transform timestamp column into a date with day (YYYY-MM-DD)
-        filtered_view_duration.loc[:, "date"] = pd.to_datetime(
-            filtered_view_duration.loc[:, "timestamp"]
-        ).dt.date
+        # If the `is_unique` filter is selected, filter out rows with duplicate
+        # `actor.account.name`
+        if self.is_unique:
+            filtered_view_duration.drop_duplicates(subset="actor.uuid", inplace=True)
 
         # Group by day and calculate sum of events per day
         count_by_date = (
@@ -91,8 +99,91 @@ class DailyVideoViews(BaseIndicator):
             .rename(columns={"id": "count"})
             .loc[:, ["date", "count"]]
         )
+
         # Calculate the total number of events
         indicator.total_views = len(filtered_view_duration.index)
-        indicator.views_count_by_date = count_by_date.to_dict("records")
+        indicator.count_by_date = count_by_date.to_dict("records")
+
+        return indicator
+
+
+class DailyCompletedVideoViews(BaseIndicator):
+    """Daily Completed Video Views indicator.
+
+    For a given video, and a date range, this indicator computes the total number
+    of `completed` views events, and the number of views per day.
+    """
+
+    def __init__(
+        self,
+        client: BaseHTTP,
+        video_uuid: str,
+        date_range: DatetimeRange,
+        is_unique: bool,
+    ):
+        """Instantiate the indicator with its parameters.
+
+        Args:
+            client: The LRS backend from which the query is to be issued
+            video_uuid: The UUID of the video on which to compute the metric
+            date_range: The date range on which to compute the indicator. It has
+                2 fields, `since` and `until` which are dates or timestamps that must be
+                in ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss.SSSZ")
+            is_unique: If true, multiple views by the same actor are counted as
+                one
+        """
+        self.client = client
+        self.video_uuid = video_uuid
+        self.date_range = date_range
+        self.is_unique = is_unique
+
+    def get_lrs_query(self) -> LRSQuery:
+        """Returns the LRS query for fetching required statements."""
+        return LRSQuery(
+            query={
+                "verb": CompletedVerb().id,
+                "activity": self.video_uuid,
+                "since": self.date_range.since.isoformat(),
+                "until": self.date_range.until.isoformat(),
+            }
+        )
+
+    def fetch_statements(self) -> List[XAPI_STATEMENT]:
+        """Executes the LRS query to obtain statements required for this indicator."""
+        return list(
+            self.client.read(
+                target=self.client.statements_endpoint, query=self.get_lrs_query()
+            )
+        )
+
+    def compute(self) -> VideoViews:
+        """Fetches statements and computes the current indicator.
+
+        Fetches the statements from the LRS, filters and aggregates them to return the
+        number of video views per day.
+        """
+        indicator = VideoViews()
+        raw_statements = self.fetch_statements()
+        if not raw_statements:
+            return indicator
+        flattened = pre_process_statements(raw_statements)
+
+        # If the `is_unique` filter is selected, filter out rows with duplicate
+        # `actor.account.name`
+        if self.is_unique:
+            flattened.drop_duplicates(subset="actor.uuid", inplace=True)
+
+        # Group by day and calculate sum of events per day
+        count_by_date = (
+            flattened.groupby(flattened["date"])
+            .count()
+            .reset_index()
+            .rename(columns={"id": "count"})
+            .loc[:, ["date", "count"]]
+        )
+
+        # Calculate the total number of events
+        indicator.total_views = len(flattened.index)
+        indicator.count_by_date = count_by_date.to_dict("records")
 
         return indicator

--- a/src/backend/plugins/video/warren_video/models.py
+++ b/src/backend/plugins/video/warren_video/models.py
@@ -16,4 +16,4 @@ class VideoViews(BaseModel):
     """Model to represent video views."""
 
     total_views: int = 0
-    views_count_by_date: List[VideoDayViews] = []
+    count_by_date: List[VideoDayViews] = []


### PR DESCRIPTION
## Purpose

Add `unique` and `complete` endpoint parameters/routes for counting completed video events and/or unique viewers

- [x] Add logic in the indicator 
- [ ] Test the new logic
- [ ] Test various parameters combination

`/views` with `complete=False`
<img width="1429" alt="image" src="https://github.com/openfun/warren/assets/26873164/9225af21-b2b5-4599-8482-449d66337f3e">

`/views` with `complete=True`
<img width="1438" alt="image" src="https://github.com/openfun/warren/assets/26873164/c72ce7aa-4160-430a-9881-6f9f461c041a">

`/viewers` with `complete=False`
<img width="1064" alt="image" src="https://github.com/openfun/warren/assets/26873164/c98b9a12-394b-46a2-a87a-8d77c7f9940c">

`/viewers` with `complete=True`
<img width="1171" alt="image" src="https://github.com/openfun/warren/assets/26873164/8fb51058-9f81-47b4-b97a-1213c77e1b72">
