### PR TITLE
(backend) Add base indicator tests

### DIFF
--- a/src/backend/core/warren/factories/base.py
+++ b/src/backend/core/warren/factories/base.py
@@ -4,6 +4,7 @@ import uuid
 from typing import List
 
 from pydantic import BaseModel
+from ralph.models.xapi.base.statements import BaseXapiStatement
 
 
 class BaseFactory:
@@ -13,7 +14,7 @@ class BaseFactory:
     model: BaseModel
 
     @classmethod
-    def build(cls, mutations: List[dict] = None) -> None:
+    def build(cls, mutations: List[dict] = None):
         """Given a template, a model and mutations, return mutated model instance."""
         instance = cls.model.parse_obj(cls.template)
         if mutations is not None:
@@ -25,8 +26,28 @@ class BaseFactory:
 class BaseXapiStatementFactory(BaseFactory):
     """Base xAPI Statement factory."""
 
+    template: dict = {
+        "object": {
+            "id": "http://adlnet.gov/expapi/activities/example",
+            "definition": {
+                "name": {"en-US": "Example Activity"},
+                "description": {"en-US": "Example activity description"},
+            },
+            "objectType": "Activity",
+        },
+        "actor": {
+            "objectType": "Agent",
+            "account": {"name": "username", "homePage": "http://fun-mooc.fr"},
+        },
+        "verb": {
+            "id": "http://adlnet.gov/expapi/verbs/completed",
+            "display": {"en-US": "completed"},
+        },
+    }
+    model: BaseXapiStatement = BaseXapiStatement
+
     @classmethod
-    def build(cls, mutations: List[dict] = None) -> None:
+    def build(cls, mutations: List[dict] = None) -> BaseXapiStatement:
         """Force statement id update."""
         instance = super().build(mutations)
         return instance.copy(update={"id": str(uuid.uuid4())})

--- a/src/backend/core/warren/tests/test_base_indicator.py
+++ b/src/backend/core/warren/tests/test_base_indicator.py
@@ -1,0 +1,95 @@
+"""Test the functions from the BaseIndicator class."""
+import pandas as pd
+
+from warren.base_indicator import add_actor_unique_id, parse_raw_statements
+from warren.factories.base import BaseXapiStatementFactory
+
+
+def test_parse_raw_statements():
+    """Test the parsing of 2 simple statements, with the addition of a "date" column."""
+    statements = [
+        BaseXapiStatementFactory.build(
+            mutations=[{"timestamp": "2023-01-01T00:10:00.000000+00:00"}]
+        ).dict(),
+        BaseXapiStatementFactory.build(
+            mutations=[{"timestamp": "2023-01-03T00:10:00.000000+00:00"}]
+        ).dict(),
+    ]
+
+    parsed = parse_raw_statements(statements)
+    assert "date" in parsed.columns
+    assert parsed["date"].equals(
+        pd.to_datetime(pd.Series(["2023-01-01", "2023-01-03"], name="date")).dt.date
+    )
+    assert len(statements) == len(parsed)
+
+
+def test_add_actor_unique_id():
+    """Test the generation of a `actor.uuid` column.
+
+    Builds a list of xAPI statements with various identification methods (See the 4
+    IFIs of the spec
+    https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#details-4), and ensure
+    the UUID is created properly, and is the same for two equal actors.
+    """
+    statements = [
+        BaseXapiStatementFactory.build(
+            mutations=[
+                {
+                    "actor": {
+                        "objectType": "Agent",
+                        "account": {"name": "John", "homePage": "http://fun-mooc.fr"},
+                    }
+                }
+            ]
+        ).dict(),
+        BaseXapiStatementFactory.build(
+            mutations=[
+                {
+                    "actor": {
+                        "objectType": "Agent",
+                        "account": {"name": "John", "homePage": "http://fun-mooc.fr"},
+                    }
+                }
+            ]
+        ).dict(),
+        BaseXapiStatementFactory.build(
+            mutations=[
+                {
+                    "actor": {
+                        "objectType": "Agent",
+                        "mbox_sha1sum": "ad85f8d83c1bc6dc8dc1dac26aff567b60e05c16",
+                    }
+                }
+            ]
+        ).dict(),
+        BaseXapiStatementFactory.build(
+            mutations=[
+                {
+                    "actor": {
+                        "objectType": "Agent",
+                        "mbox": "mailto:info@xapi.com",
+                    }
+                }
+            ]
+        ).dict(),
+        BaseXapiStatementFactory.build(
+            mutations=[
+                {
+                    "actor": {
+                        "openid": "http://tyler.openid.example.com",
+                        "objectType": "Agent",
+                    }
+                }
+            ]
+        ).dict(),
+    ]
+
+    statements = parse_raw_statements(statements)
+    statements = add_actor_unique_id(statements)
+    assert "actor.uuid" in statements.columns
+    assert statements["actor.uuid"].notna
+    # Check that 2 identical actors have the same UUID
+    uuids_john = statements[statements["actor.account.name"] == "John"]["actor.uuid"]
+    assert len(uuids_john) == 2
+    assert len(uuids_john.unique()) == 1


### PR DESCRIPTION
## Purpose

Base indicators was merged before it had tests, in order to limit the size of the PR, and as it already had many discussions. This PR adds the missing tests.

## Proposal

Add unit tests for the `parse_raw_statements` and the `add_actor_unique_id` functions of the `base_indicator.py` file.
