### PR TITLE
migrate to pydantic v2

### DIFF
--- a/src/api/core/pyproject.toml
+++ b/src/api/core/pyproject.toml
@@ -29,10 +29,11 @@ keywords = ["Analytics", "xAPI", "LRS", "LTI"]
 dependencies = [
     "arrow==1.2.2",
     "elasticsearch[async]==8.6.2",
-    "fastapi==0.95.2",
+    "fastapi==0.100.0",
     "importlib-metadata==6.6.0",
     "pandas==2.0.2",
-    "pydantic[dotenv]==1.10.8",
+    "pydantic[dotenv]==2.0.3",
+    "pydantic-settings==2.0.2",
     "rfc3987==1.3.8",
     "sentry-sdk[fastapi]==1.15.0",
     "uvicorn[standard]==0.20.0",

--- a/src/api/core/warren/conf.py
+++ b/src/api/core/warren/conf.py
@@ -3,9 +3,10 @@
 import io
 from datetime import timedelta
 from pathlib import Path
-from typing import List, Union
+from typing import List, Set, Union
 
-from pydantic import AnyHttpUrl, BaseModel, BaseSettings
+from pydantic import AnyHttpUrl, BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class ESClientOptions(BaseModel):
@@ -17,6 +18,14 @@ class ESClientOptions(BaseModel):
 
 class Settings(BaseSettings):
     """Pydantic model for Warren's global environment & configuration settings."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding=getattr(io, "LOCALE_ENCODING", "utf8"),
+        env_prefix="WARREN_",
+        env_nested_delimiter="__",
+        case_sensitive=True,
+    )
 
     # LRS backend
     LRS_HOSTS: Union[List[AnyHttpUrl], AnyHttpUrl]
@@ -32,7 +41,7 @@ class Settings(BaseSettings):
     MAX_DATETIMERANGE_SPAN: timedelta = timedelta(days=365)  # 1 year shift from since
     DEFAULT_DATETIMERANGE_SPAN: timedelta = timedelta(days=7)  # 7 days shift from until
     DATE_FORMAT: str = "YYYY-MM-DD"
-    XAPI_ACTOR_IDENTIFIER_PATHS = {
+    XAPI_ACTOR_IDENTIFIER_PATHS: Set[str] = {
         "actor.account.name",
         "actor.account.homePage",
         "actor.mbox",
@@ -51,15 +60,6 @@ class Settings(BaseSettings):
     def SERVER_URL(self):
         """Get the full server URL."""
         return f"{self.SERVER_PROTOCOL}://{self.SERVER_HOST}:{self.SERVER_PORT}"
-
-    class Config:
-        """Pydantic Configuration."""
-
-        case_sensitive = True
-        env_file = ".env"
-        env_file_encoding = getattr(io, "LOCALE_ENCODING", "utf8")
-        env_nested_delimiter = "__"
-        env_prefix = "WARREN_"
 
 
 settings = Settings()

--- a/src/api/core/warren/factories/base.py
+++ b/src/api/core/warren/factories/base.py
@@ -16,10 +16,10 @@ class BaseFactory:
     @classmethod
     def build(cls, mutations: List[dict] = None):
         """Given a template, a model and mutations, return mutated model instance."""
-        instance = cls.model.parse_obj(cls.template)
+        instance = cls.model.model_validate(cls.template)
         if mutations is not None:
             for mutation in mutations:
-                instance = instance.copy(update=mutation)
+                instance = instance.model_copy(update=mutation)
         return instance
 
 
@@ -50,4 +50,4 @@ class BaseXapiStatementFactory(BaseFactory):
     def build(cls, mutations: List[dict] = None) -> BaseXapiStatement:
         """Force statement id update."""
         instance = super().build(mutations)
-        return instance.copy(update={"id": str(uuid.uuid4())})
+        return instance.model_copy(update={"id": str(uuid.uuid4())})

--- a/src/api/core/warren/tests/test_base_indicator.py
+++ b/src/api/core/warren/tests/test_base_indicator.py
@@ -10,10 +10,10 @@ def test_parse_raw_statements():
     statements = [
         BaseXapiStatementFactory.build(
             mutations=[{"timestamp": "2023-01-01T00:10:00.000000+00:00"}]
-        ).dict(),
+        ).model_dump(),
         BaseXapiStatementFactory.build(
             mutations=[{"timestamp": "2023-01-03T00:10:00.000000+00:00"}]
-        ).dict(),
+        ).model_dump(),
     ]
 
     parsed = parse_raw_statements(statements)
@@ -42,7 +42,7 @@ def test_add_actor_unique_id():
                     }
                 }
             ]
-        ).dict(),
+        ).model_dump(),
         BaseXapiStatementFactory.build(
             mutations=[
                 {
@@ -52,7 +52,7 @@ def test_add_actor_unique_id():
                     }
                 }
             ]
-        ).dict(),
+        ).model_dump(),
         BaseXapiStatementFactory.build(
             mutations=[
                 {
@@ -62,7 +62,7 @@ def test_add_actor_unique_id():
                     }
                 }
             ]
-        ).dict(),
+        ).model_dump(),
         BaseXapiStatementFactory.build(
             mutations=[
                 {
@@ -72,7 +72,7 @@ def test_add_actor_unique_id():
                     }
                 }
             ]
-        ).dict(),
+        ).model_dump(),
         BaseXapiStatementFactory.build(
             mutations=[
                 {
@@ -82,7 +82,7 @@ def test_add_actor_unique_id():
                     }
                 }
             ]
-        ).dict(),
+        ).model_dump(),
     ]
 
     statements = parse_raw_statements(statements)

--- a/src/api/plugins/video/tests/test_api.py
+++ b/src/api/plugins/video/tests/test_api.py
@@ -57,7 +57,7 @@ async def test_views_valid_video_id_path_but_no_matching_video(
     )
 
     assert response.status_code == 200
-    assert VideoViews.parse_obj(response.json()) == VideoViews(
+    assert VideoViews.model_validate(response.json()) == VideoViews(
         total_views=0,
         views_count_by_date=[],
     )

--- a/src/api/plugins/video/warren_video/conf.py
+++ b/src/api/plugins/video/warren_video/conf.py
@@ -2,22 +2,21 @@
 
 import io
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
     """Pydantic model for Warren's video configuration settings."""
 
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding=getattr(io, "LOCALE_ENCODING", "utf8"),
+        env_prefix="WARREN_VIDEO_",
+        env_nested_delimiter="__",
+        case_sensitive=True,
+    )
+
     VIEWS_COUNT_TIME_THRESHOLD: int = 30  # seconds
-
-    class Config:
-        """Pydantic Configuration."""
-
-        case_sensitive = True
-        env_file = ".env"
-        env_file_encoding = getattr(io, "LOCALE_ENCODING", "utf8")
-        env_nested_delimiter = "__"
-        env_prefix = "WARREN_VIDEO_"
 
 
 settings = Settings()


### PR DESCRIPTION
## Purpose

Upgrade to `Pydantic` version 2 for improved performances and enhanced usability

## Proposal

I manually updated the `Pydantic` Python sources based on the [Migration guide](https://docs.pydantic.dev/latest/migration/). Although I attempted to use the code transformation tool `bump-pydantic`, the migration process was only partially successful.

