### PR TITLE
🩹(api) revamp the neglected backend within `bin/pytest`

### DIFF
--- a/bin/pytest
+++ b/bin/pytest
@@ -5,5 +5,5 @@ DOCKER_USER="$(id -u):$(id -g)"
 
 DOCKER_USER=${DOCKER_USER} docker compose run \
   --rm \
-  backend \
+  api \
   pytest -c core/pyproject.toml "$@"


### PR DESCRIPTION
After renaming Docker Compose services, I overlooked updating the bin/pytest bash script to align with the changes.
