### PR TITLE
🩹(project) ensure the pre-commit hook runs only on staged diffs 

### DIFF
--- a/bin/git-hook-pre-commit
+++ b/bin/git-hook-pre-commit
@@ -24,12 +24,12 @@ echo "pre-commit hook: checking trailing whitespace…"
 git diff-index --check --cached "$against" --
 
 # Run the necessary commands to check modified code sources.
-if git diff --cached --name-only | grep -q 'src/api'; then
+if git diff --staged --cached --name-only | grep -q 'src/api'; then
   make lint-api
 fi
-if git diff --cached --name-only | grep -q 'src/app'; then
+if git diff --staged --cached --name-only | grep -q 'src/app'; then
   make lint-app
 fi
-if git diff --cached --name-only | grep -q 'src/frontend'; then
+if git diff --staged --cached --name-only | grep -q 'src/frontend'; then
   make lint-frontend
 fi


### PR DESCRIPTION
Ensure the hook runs only on staged diffs during partial commits. During a partial commit, a developer may choose to commit only specific changes while leaving other modifications unstaged. The hook should only operate on the staged changes to ensure it does not interfere with uncommitted or unrelated code.