### PR TITLE
🐛(api) return a count of 0 if there were no events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,6 @@ and this project adheres to
 - Rename video_uuid to follow xAPI semantic
 - Use concise names in indicator and models
 - Refactor the LRS client to be asynchronous
+- Fix count of 0 in all video endpoints
 
 [unreleased]: https://github.com/openfun/warren

--- a/src/api/core/warren/models.py
+++ b/src/api/core/warren/models.py
@@ -1,10 +1,14 @@
 """Warren's core models."""
 from enum import Enum
+from functools import reduce
+from itertools import groupby
 from typing import Any, Dict, Generic, List, TypeVar
 
+import arrow
 from pydantic.main import BaseModel
 
 from warren.fields import Date
+from warren.filters import DatetimeRange
 
 
 class StatusEnum(str, Enum):
@@ -39,9 +43,41 @@ class DailyCount(BaseModel):
     date: Date
     count: int = 0
 
+    def __add__(self, other):
+        """Add counters for two DailyCount instances with the same date."""
+        if self.date != other.date:
+            raise Exception("Cannot add two DailyCount instances with different dates")
+        return DailyCount(date=self.date, count=self.count + other.count)
+
 
 class DailyCounts(BaseModel):
     """Base model to represent daily counts summary."""
 
     total: int = 0
     counts: List[DailyCount] = []
+
+    @classmethod
+    def from_range(cls, date_range: DatetimeRange):
+        """Initialize DailyCounts from a date range."""
+        return cls(
+            counts=[
+                DailyCount(date=d)
+                for d in arrow.Arrow.range("day", date_range.since, date_range.until)
+            ]
+        )
+
+    def merge_counts(self, counts: List[DailyCount]):
+        """Merge DailyCount objects by date and aggregate counts.
+
+        This method allows us to combine a list of DailyCount objects into
+        the existing 'counts' list, aggregating the counts for each date
+        and ensuring that 'counts' contains only unique DailyCount objects
+        with one count per day.
+        """
+        self.counts += counts
+        self.counts.sort(key=lambda x: x.date)
+        self.counts = [
+            reduce(lambda x, y: x + y, v)
+            for k, v in groupby(self.counts, lambda dc: dc.date)
+        ]
+        self.total = sum(dc.count for dc in self.counts)

--- a/src/api/plugins/video/tests/test_api.py
+++ b/src/api/plugins/video/tests/test_api.py
@@ -57,10 +57,19 @@ async def test_views_valid_video_id_path_but_no_matching_video(
     )
 
     assert response.status_code == 200
-    assert DailyCounts.parse_obj(response.json()) == DailyCounts(
-        total=0,
-        counts=[],
-    )
+
+    # Parse the response to obtain video views count_by_date
+    video_views = (Response[DailyCounts]).parse_obj(response.json()).content
+
+    # Counting all views is expected
+    expected_video_views = {
+        "total": 0,
+        "counts": [
+            {"date": "2023-01-01", "count": 0},
+        ],
+    }
+
+    assert video_views == expected_video_views
 
 
 @pytest.mark.anyio
@@ -122,6 +131,7 @@ async def test_views_backend_query(http_client: AsyncClient, httpx_mock: HTTPXMo
         "counts": [
             {"date": "2020-01-01", "count": 2},
             {"date": "2020-01-02", "count": 1},
+            {"date": "2020-01-03", "count": 0},
         ],
     }
 
@@ -194,6 +204,8 @@ async def test_unique_views_backend_query(
         "total": 1,
         "counts": [
             {"date": "2020-01-01", "count": 1},
+            {"date": "2020-01-02", "count": 0},
+            {"date": "2020-01-03", "count": 0},
         ],
     }
 
@@ -244,10 +256,19 @@ async def test_downloads_valid_video_id_path_but_no_matching_video(
     )
 
     assert response.status_code == 200
-    assert DailyCounts.parse_obj(response.json()) == DailyCounts(
-        total=0,
-        counts=[],
-    )
+
+    # Parse the response to obtain video downloads count_by_date
+    video_downloads = (Response[DailyCounts]).parse_obj(response.json()).content
+
+    # Counting all downloads is expected
+    expected_video_downloads = {
+        "total": 0,
+        "counts": [
+            {"date": "2023-01-01", "count": 0},
+        ],
+    }
+
+    assert video_downloads == expected_video_downloads
 
 
 @pytest.mark.anyio
@@ -308,6 +329,7 @@ async def test_downloads_backend_query(http_client: AsyncClient, httpx_mock: HTT
         "counts": [
             {"date": "2020-01-01", "count": 2},
             {"date": "2020-01-02", "count": 1},
+            {"date": "2020-01-03", "count": 0},
         ],
     }
 
@@ -379,6 +401,8 @@ async def test_unique_downloads_backend_query(
         "total": 1,
         "counts": [
             {"date": "2020-01-01", "count": 1},
+            {"date": "2020-01-02", "count": 0},
+            {"date": "2020-01-03", "count": 0},
         ],
     }
 


### PR DESCRIPTION
## Purpose

The API should return a count of 0 if there were no events on a given date.

## Proposal

This fix is inspired by @jmaupetit previous works on the API, you could find [here](https://github.com/openfun/warren/blob/e1b60d5d0f4a35ce482872d2d3c62ba35deed49a/src/backend/plugins/video/warren_video/api.py).

During the indicator computation, it is essential to initialize the DailyCounts with a count of zero for each date within the expected date range. Subsequently, the counts should be updated with the appropriate values. This approach guarantees that each date will have a returned value, and the dates will be sorted accordingly.

- [x] Fix DailyVideoViews indicator
- [X] Fix DailyCompletedVideoViews indicator
- [x] Fix DailyVideoDownloads indicator.
- [x] Update indicators' tests.
