### PR TITLE
♻️(api) rename video uuid to match xAPI semantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,6 @@ and this project adheres to
 - Rename the API directory to a more descriptive name.
 - Add a select and date range picker to the web dashboard.
 - Implement video downloads endpoint
+- Rename video_uuid to follow xAPI semantic
 
 [unreleased]: https://github.com/openfun/warren

--- a/src/api/plugins/video/tests/test_api.py
+++ b/src/api/plugins/video/tests/test_api.py
@@ -15,17 +15,17 @@ from warren_video.factories import VideoDownloadedFactory, VideoPlayedFactory
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "video_uuid", ["foo", "foo/bar", "/foo/bar", "foo%2Fbar", "%2Ffoo%2Fbar"]
+    "video_id", ["foo", "foo/bar", "/foo/bar", "foo%2Fbar", "%2Ffoo%2Fbar"]
 )
-async def test_views_invalid_video_uuid(http_client: AsyncClient, video_uuid: str):
-    """Test the video views endpoint with an invalid `video_uuid` path."""
+async def test_views_invalid_video_id(http_client: AsyncClient, video_id: str):
+    """Test the video views endpoint with an invalid `video_id` path."""
     date_query_params = {
         "since": "2023-01-01",
         "until": "2023-01-31",
     }
 
     response = await http_client.get(
-        f"/api/v1/video/{video_uuid}/views", params=date_query_params
+        f"/api/v1/video/{video_id}/views", params=date_query_params
     )
 
     assert response.status_code == 422
@@ -33,10 +33,10 @@ async def test_views_invalid_video_uuid(http_client: AsyncClient, video_uuid: st
 
 
 @pytest.mark.anyio
-async def test_views_valid_video_uuid_path_but_no_matching_video(
+async def test_views_valid_video_id_path_but_no_matching_video(
     http_client: AsyncClient, httpx_mock: HTTPXMock
 ):
-    """Test the video views endpoint with a valid `video_uuid` but no results."""
+    """Test the video views endpoint with a valid `video_id` but no results."""
     lrs_client.base_url = "http://fake-lrs.com"
 
     # Mock the call to the LRS so that it would return no statements, as it
@@ -67,7 +67,7 @@ async def test_views_valid_video_uuid_path_but_no_matching_video(
 async def test_views_backend_query(http_client: AsyncClient, httpx_mock: HTTPXMock):
     """Test the video views endpoint backend query results."""
     # Define 3 video views fixtures
-    video_uuid = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
+    video_id = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
     video_views_fixtures = [
         {"timestamp": "2020-01-01T00:00:00.000+00:00", "time": 100},
         {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 200},
@@ -78,7 +78,7 @@ async def test_views_backend_query(http_client: AsyncClient, httpx_mock: HTTPXMo
     video_statements = [
         VideoPlayedFactory.build(
             [
-                {"object": {"id": video_uuid, "objectType": "Activity"}},
+                {"object": {"id": video_id, "objectType": "Activity"}},
                 {"verb": {"id": PlayedVerb().id}},
                 {"result": {"extensions": {RESULT_EXTENSION_TIME: view_data["time"]}}},
                 {"timestamp": view_data["timestamp"]},
@@ -104,7 +104,7 @@ async def test_views_backend_query(http_client: AsyncClient, httpx_mock: HTTPXMo
     # Perform the call to warren backend. When fetching the LRS statements, it will
     # get the above mocked statements
     response = await http_client.get(
-        url=f"/api/v1/video/{video_uuid}/views",
+        url=f"/api/v1/video/{video_id}/views",
         params={
             "since": "2020-01-01",
             "until": "2020-01-03",
@@ -134,7 +134,7 @@ async def test_unique_views_backend_query(
 ):
     """Test the video views endpoint, with parameter unique=True."""
     # Define 3 video views fixtures
-    video_uuid = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
+    video_id = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
     video_views_fixtures = [
         {"timestamp": "2020-01-01T00:00:00.000+00:00", "time": 100},
         {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 200},
@@ -151,7 +151,7 @@ async def test_unique_views_backend_query(
                         "account": {"name": "John", "homePage": "http://fun-mooc.fr"},
                     }
                 },
-                {"object": {"id": video_uuid, "objectType": "Activity"}},
+                {"object": {"id": video_id, "objectType": "Activity"}},
                 {"verb": {"id": PlayedVerb().id}},
                 {"result": {"extensions": {RESULT_EXTENSION_TIME: view_data["time"]}}},
                 {"timestamp": view_data["timestamp"]},
@@ -177,7 +177,7 @@ async def test_unique_views_backend_query(
     # Perform the call to warren backend. When fetching the LRS statements, it will
     # get the above mocked statements
     response = await http_client.get(
-        url=f"/api/v1/video/{video_uuid}/views?unique=true",
+        url=f"/api/v1/video/{video_id}/views?unique=true",
         params={
             "since": "2020-01-01",
             "until": "2020-01-03",
@@ -202,17 +202,17 @@ async def test_unique_views_backend_query(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "video_uuid", ["foo", "foo/bar", "/foo/bar", "foo%2Fbar", "%2Ffoo%2Fbar"]
+    "video_id", ["foo", "foo/bar", "/foo/bar", "foo%2Fbar", "%2Ffoo%2Fbar"]
 )
-async def test_downloads_invalid_video_uuid(http_client: AsyncClient, video_uuid: str):
-    """Test the video downloads endpoint with an invalid `video_uuid` path."""
+async def test_downloads_invalid_video_id(http_client: AsyncClient, video_id: str):
+    """Test the video downloads endpoint with an invalid `video_id` path."""
     date_query_params = {
         "since": "2023-01-01",
         "until": "2023-01-31",
     }
 
     response = await http_client.get(
-        f"/api/v1/video/{video_uuid}/downloads", params=date_query_params
+        f"/api/v1/video/{video_id}/downloads", params=date_query_params
     )
 
     assert response.status_code == 422
@@ -220,10 +220,10 @@ async def test_downloads_invalid_video_uuid(http_client: AsyncClient, video_uuid
 
 
 @pytest.mark.anyio
-async def test_downloads_valid_video_uuid_path_but_no_matching_video(
+async def test_downloads_valid_video_id_path_but_no_matching_video(
     http_client: AsyncClient, httpx_mock: HTTPXMock
 ):
-    """Test the video downloads endpoint with a valid `video_uuid` but no results."""
+    """Test the video downloads endpoint with a valid `video_id` but no results."""
     lrs_client.base_url = "http://fake-lrs.com"
 
     # Mock the call to the LRS so that it would return no statements, as it
@@ -254,7 +254,7 @@ async def test_downloads_valid_video_uuid_path_but_no_matching_video(
 async def test_downloads_backend_query(http_client: AsyncClient, httpx_mock: HTTPXMock):
     """Test the video downloads endpoint backend query results."""
     # Define 3 video downloads fixtures
-    video_uuid = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
+    video_id = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
     video_download_timestamps = [
         "2020-01-01T00:00:00.000+00:00",
         "2020-01-01T00:00:30.000+00:00",
@@ -265,7 +265,7 @@ async def test_downloads_backend_query(http_client: AsyncClient, httpx_mock: HTT
     video_statements = [
         VideoDownloadedFactory.build(
             [
-                {"object": {"id": video_uuid, "objectType": "Activity"}},
+                {"object": {"id": video_id, "objectType": "Activity"}},
                 {"verb": {"id": DownloadedVerb().id}},
                 {"timestamp": download_timestamp},
             ]
@@ -290,7 +290,7 @@ async def test_downloads_backend_query(http_client: AsyncClient, httpx_mock: HTT
     # Perform the call to warren backend. When fetching the LRS statements, it will
     # get the above mocked statements
     response = await http_client.get(
-        url=f"/api/v1/video/{video_uuid}/downloads",
+        url=f"/api/v1/video/{video_id}/downloads",
         params={
             "since": "2020-01-01",
             "until": "2020-01-03",
@@ -320,7 +320,7 @@ async def test_unique_downloads_backend_query(
 ):
     """Test the video downloads endpoint, with parameter unique=True."""
     # Define 3 video views fixtures
-    video_uuid = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
+    video_id = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
     video_download_timestamps = [
         "2020-01-01T00:00:00.000+00:00",
         "2020-01-01T00:00:30.000+00:00",
@@ -337,7 +337,7 @@ async def test_unique_downloads_backend_query(
                         "account": {"name": "John", "homePage": "http://fun-mooc.fr"},
                     }
                 },
-                {"object": {"id": video_uuid, "objectType": "Activity"}},
+                {"object": {"id": video_id, "objectType": "Activity"}},
                 {"verb": {"id": DownloadedVerb().id}},
                 {"timestamp": download_timestamp},
             ]
@@ -362,7 +362,7 @@ async def test_unique_downloads_backend_query(
     # Perform the call to warren backend. When fetching the LRS statements, it will
     # get the above mocked statements
     response = await http_client.get(
-        url=f"/api/v1/video/{video_uuid}/downloads?unique=true",
+        url=f"/api/v1/video/{video_id}/downloads?unique=true",
         params={
             "since": "2020-01-01",
             "until": "2020-01-03",

--- a/src/api/plugins/video/warren_video/api.py
+++ b/src/api/plugins/video/warren_video/api.py
@@ -20,17 +20,17 @@ router = APIRouter(
 logger = logging.getLogger(__name__)
 
 
-@router.get("/{video_uuid:path}/views")
+@router.get("/{video_id:path}/views")
 async def views(
-    video_uuid: IRI,
+    video_id: IRI,
     filters: Annotated[BaseQueryFilters, Depends()],
     complete: bool = False,
     unique: bool = False,
 ) -> Response[DailyCounts]:
-    """Number of views for `video_uuid` in the `since` -> `until` date range."""
+    """Number of views for `video_id` in the `since` -> `until` date range."""
     indicator_kwargs = {
         "client": lrs_client,
-        "video_uuid": video_uuid,
+        "video_id": video_id,
         "date_range": DatetimeRange(since=filters.since, until=filters.until),
         "is_unique": unique,
     }
@@ -51,16 +51,16 @@ async def views(
     return response
 
 
-@router.get("/{video_uuid:path}/downloads")
+@router.get("/{video_id:path}/downloads")
 async def downloads(
-    video_uuid: IRI,
+    video_id: IRI,
     filters: Annotated[BaseQueryFilters, Depends()],
     unique: bool = False,
 ) -> Response[DailyCounts]:
-    """Number of downloads for `video_uuid` in the `since` -> `until` date range."""
+    """Number of downloads for `video_id` in the `since` -> `until` date range."""
     indicator = DailyVideoDownloads(
         client=lrs_client,
-        video_uuid=video_uuid,
+        video_id=video_id,
         date_range=DatetimeRange(since=filters.since, until=filters.until),
         is_unique=unique,
     )

--- a/src/api/plugins/video/warren_video/indicators.py
+++ b/src/api/plugins/video/warren_video/indicators.py
@@ -23,7 +23,7 @@ class DailyVideoViews(BaseIndicator):
     def __init__(
         self,
         client: BaseHTTP,
-        video_uuid: str,
+        video_id: str,
         date_range: DatetimeRange,
         is_unique: bool,
     ):
@@ -31,7 +31,7 @@ class DailyVideoViews(BaseIndicator):
 
         Args:
             client: The LRS backend to query
-            video_uuid: The UUID of the video on which to compute the metric
+            video_id: The ID of the video on which to compute the metric
             date_range: The date range on which to compute the indicator. It has
                 2 fields, `since` and `until` which are dates or timestamps that must be
                 in ISO format (YYYY-MM-DD, YYYY-MM-DDThh:mm:ss.sss±hh:mm or
@@ -40,7 +40,7 @@ class DailyVideoViews(BaseIndicator):
                 one
         """
         self.client = client
-        self.video_uuid = video_uuid
+        self.video_id = video_id
         self.date_range = date_range
         self.is_unique = is_unique
 
@@ -49,7 +49,7 @@ class DailyVideoViews(BaseIndicator):
         return LRSQuery(
             query={
                 "verb": PlayedVerb().id,
-                "activity": self.video_uuid,
+                "activity": self.video_id,
                 "since": self.date_range.since.isoformat(),
                 "until": self.date_range.until.isoformat(),
             }
@@ -117,7 +117,7 @@ class DailyCompletedVideoViews(BaseIndicator):
     def __init__(
         self,
         client: BaseHTTP,
-        video_uuid: str,
+        video_id: str,
         date_range: DatetimeRange,
         is_unique: bool,
     ):
@@ -125,7 +125,7 @@ class DailyCompletedVideoViews(BaseIndicator):
 
         Args:
             client: The LRS backend from which the query is to be issued
-            video_uuid: The UUID of the video on which to compute the metric
+            video_id: The ID of the video on which to compute the metric
             date_range: The date range on which to compute the indicator. It has
                 2 fields, `since` and `until` which are dates or timestamps that must be
                 in ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss.SSSZ")
@@ -133,7 +133,7 @@ class DailyCompletedVideoViews(BaseIndicator):
                 one
         """
         self.client = client
-        self.video_uuid = video_uuid
+        self.video_id = video_id
         self.date_range = date_range
         self.is_unique = is_unique
 
@@ -142,7 +142,7 @@ class DailyCompletedVideoViews(BaseIndicator):
         return LRSQuery(
             query={
                 "verb": CompletedVerb().id,
-                "activity": self.video_uuid,
+                "activity": self.video_id,
                 "since": self.date_range.since.isoformat(),
                 "until": self.date_range.until.isoformat(),
             }
@@ -198,7 +198,7 @@ class DailyVideoDownloads(BaseIndicator):
     def __init__(
         self,
         client: BaseHTTP,
-        video_uuid: str,
+        video_id: str,
         date_range: DatetimeRange,
         is_unique: bool,
     ):
@@ -206,7 +206,7 @@ class DailyVideoDownloads(BaseIndicator):
 
         Args:
             client: The LRS backend to query
-            video_uuid: The UUID of the video on which to compute the metric
+            video_id: The ID of the video on which to compute the metric
             date_range: The date range on which to compute the indicator. It has
                 2 fields, `since` and `until` which are dates or timestamps that must be
                 in ISO format (YYYY-MM-DD, YYYY-MM-DDThh:mm:ss.sss±hh:mm or
@@ -214,7 +214,7 @@ class DailyVideoDownloads(BaseIndicator):
             is_unique: If true, multiple downloads by the same actor are counted as one
         """
         self.client = client
-        self.video_uuid = video_uuid
+        self.video_id = video_id
         self.date_range = date_range
         self.is_unique = is_unique
 
@@ -223,7 +223,7 @@ class DailyVideoDownloads(BaseIndicator):
         return LRSQuery(
             query={
                 "verb": DownloadedVerb().id,
-                "activity": self.video_uuid,
+                "activity": self.video_id,
                 "since": self.date_range.since.isoformat(),
                 "until": self.date_range.until.isoformat(),
             }


### PR DESCRIPTION
The video identifier is an IRI that can be a UUID in the form of an IRI, but it’s not a UUID. This corrects video’s semantic representation and avoids any potential confusion caused by misleading naming.
