### PR TITLE
♻️(api) use concise names in indicators and models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,6 @@ and this project adheres to
 - Add a select and date range picker to the web dashboard.
 - Implement video downloads endpoint
 - Rename video_uuid to follow xAPI semantic
+- Use concise names in indicator and models
 
 [unreleased]: https://github.com/openfun/warren

--- a/src/api/core/warren/models.py
+++ b/src/api/core/warren/models.py
@@ -43,5 +43,5 @@ class DailyCount(BaseModel):
 class DailyCounts(BaseModel):
     """Base model to represent daily counts summary."""
 
-    total_count: int = 0
-    count_by_date: List[DailyCount] = []
+    total: int = 0
+    counts: List[DailyCount] = []

--- a/src/api/plugins/video/tests/test_api.py
+++ b/src/api/plugins/video/tests/test_api.py
@@ -58,8 +58,8 @@ async def test_views_valid_video_id_path_but_no_matching_video(
 
     assert response.status_code == 200
     assert DailyCounts.parse_obj(response.json()) == DailyCounts(
-        total_count=0,
-        count_by_date=[],
+        total=0,
+        counts=[],
     )
 
 
@@ -113,13 +113,13 @@ async def test_views_backend_query(http_client: AsyncClient, httpx_mock: HTTPXMo
 
     assert response.status_code == 200
 
-    # Parse the response to obtain video views count_by_date
+    # Parse the response to obtain video views counts
     video_views = (Response[DailyCounts]).parse_obj(response.json()).content
 
     # Counting all views is expected
     expected_video_views = {
-        "total_count": 3,
-        "count_by_date": [
+        "total": 3,
+        "counts": [
             {"date": "2020-01-01", "count": 2},
             {"date": "2020-01-02", "count": 1},
         ],
@@ -186,13 +186,13 @@ async def test_unique_views_backend_query(
 
     assert response.status_code == 200
 
-    # Parse the response to obtain video views count_by_date
+    # Parse the response to obtain video views counts
     video_views = (Response[DailyCounts]).parse_obj(response.json()).content
 
     # Counting only the first view is expected
     expected_video_views = {
-        "total_count": 1,
-        "count_by_date": [
+        "total": 1,
+        "counts": [
             {"date": "2020-01-01", "count": 1},
         ],
     }
@@ -245,8 +245,8 @@ async def test_downloads_valid_video_id_path_but_no_matching_video(
 
     assert response.status_code == 200
     assert DailyCounts.parse_obj(response.json()) == DailyCounts(
-        total_count=0,
-        count_by_date=[],
+        total=0,
+        counts=[],
     )
 
 
@@ -299,13 +299,13 @@ async def test_downloads_backend_query(http_client: AsyncClient, httpx_mock: HTT
 
     assert response.status_code == 200
 
-    # Parse the response to obtain video downloads count_by_date
+    # Parse the response to obtain video downloads counts
     video_downloads = (Response[DailyCounts]).parse_obj(response.json()).content
 
     # Counting all downloads is expected
     expected_video_downloads = {
-        "total_count": 3,
-        "count_by_date": [
+        "total": 3,
+        "counts": [
             {"date": "2020-01-01", "count": 2},
             {"date": "2020-01-02", "count": 1},
         ],
@@ -371,13 +371,13 @@ async def test_unique_downloads_backend_query(
 
     assert response.status_code == 200
 
-    # Parse the response to obtain video downloads count_by_date
+    # Parse the response to obtain video downloads counts
     video_downloads = (Response[DailyCounts]).parse_obj(response.json()).content
 
     # Counting only the first download is expected
     expected_video_downloads = {
-        "total_count": 1,
-        "count_by_date": [
+        "total": 1,
+        "counts": [
             {"date": "2020-01-01", "count": 1},
         ],
     }

--- a/src/api/plugins/video/warren_video/indicators.py
+++ b/src/api/plugins/video/warren_video/indicators.py
@@ -69,10 +69,10 @@ class DailyVideoViews(BaseIndicator):
         Fetches the statements from the LRS, filters and aggregates them to return the
         number of video views per day.
         """
-        indicator = DailyCounts()
+        daily_counts = DailyCounts()
         raw_statements = self.fetch_statements()
         if not raw_statements:
-            return indicator
+            return daily_counts
         flattened = pre_process_statements(raw_statements)
 
         # Filter out video played events before the configured time threshold
@@ -101,10 +101,10 @@ class DailyVideoViews(BaseIndicator):
         )
 
         # Calculate the total number of events
-        indicator.total_count = len(filtered_view_duration.index)
-        indicator.count_by_date = count_by_date.to_dict("records")
+        daily_counts.total = len(filtered_view_duration.index)
+        daily_counts.counts = count_by_date.to_dict("records")
 
-        return indicator
+        return daily_counts
 
 
 class DailyCompletedVideoViews(BaseIndicator):
@@ -162,10 +162,10 @@ class DailyCompletedVideoViews(BaseIndicator):
         Fetches the statements from the LRS, filters and aggregates them to return the
         number of video views per day.
         """
-        indicator = DailyCounts()
+        daily_counts = DailyCounts()
         raw_statements = self.fetch_statements()
         if not raw_statements:
-            return indicator
+            return daily_counts
         flattened = pre_process_statements(raw_statements)
 
         # Filter out duplicate 'actor.uid' if 'is_unique' is selected.
@@ -182,10 +182,10 @@ class DailyCompletedVideoViews(BaseIndicator):
         )
 
         # Calculate the total number of events
-        indicator.total_count = len(flattened.index)
-        indicator.count_by_date = count_by_date.to_dict("records")
+        daily_counts.total = len(flattened.index)
+        daily_counts.counts = count_by_date.to_dict("records")
 
-        return indicator
+        return daily_counts
 
 
 class DailyVideoDownloads(BaseIndicator):
@@ -243,10 +243,10 @@ class DailyVideoDownloads(BaseIndicator):
         Fetches the statements from the LRS, filters and aggregates them to return the
         number of video downloads per day.
         """
-        indicator = DailyCounts()
+        daily_counts = DailyCounts()
         raw_statements = self.fetch_statements()
         if not raw_statements:
-            return indicator
+            return daily_counts
         preprocessed_statements = pre_process_statements(raw_statements)
 
         # Filter out duplicate 'actor.uid' if 'is_unique' is selected.
@@ -263,7 +263,7 @@ class DailyVideoDownloads(BaseIndicator):
         )
 
         # Calculate the total number of downloads
-        indicator.total_count = len(preprocessed_statements.index)
-        indicator.count_by_date = count_by_date.to_dict("records")
+        daily_counts.total = len(preprocessed_statements.index)
+        daily_counts.counts = count_by_date.to_dict("records")
 
-        return indicator
+        return daily_counts

--- a/src/frontend/packages/ui/video/Views.tsx
+++ b/src/frontend/packages/ui/video/Views.tsx
@@ -58,7 +58,7 @@ export const DailyViews: React.FC = () => {
   const parseSeries = (item: VideoViewsResponse): Series => ({
     id: item?.id,
     name: item.id.slice(-5) || "",
-    data: item.count_by_date.map((day) => day.count) || [],
+    data: item.counts.map((day) => day.count) || [],
     type: "line",
     smooth: 0.2,
     symbol: "none",
@@ -68,7 +68,7 @@ export const DailyViews: React.FC = () => {
   });
 
   const parseXAxis = (item: VideoViewsResponse): Array<string> =>
-    item.count_by_date.map((day) => day.date) || [];
+    item.counts.map((day) => day.date) || [];
 
   const formattedOption = useMemo(() => {
     if (!validData.length) {

--- a/src/frontend/packages/ui/video/types/index.ts
+++ b/src/frontend/packages/ui/video/types/index.ts
@@ -5,6 +5,6 @@ export type VideoViewsResponseItem = {
 
 export type VideoViewsResponse = {
   id: string;
-  total_count: number;
-  count_by_date: Array<VideoViewsResponseItem>;
+  total: number;
+  counts: Array<VideoViewsResponseItem>;
 };


### PR DESCRIPTION
## Purpose

Optimize code readability, by avoiding redundant info and use concise names in indicators

## Proposal

Note: `count_by_date` temporary vars in all `compute` methods haven't been renamed on purpose. These will change with #47.

- [X] Rename `total_count` to `total` in `DailyCounts`.
- [X] Rename `count_by_date` to `counts` in `DailyCounts`.
- [X] Rename `indicator` to `daily_counts` in all video indicators.
