### PR TITLE
🩹(renovate) prefix ignored dev dependencies with `dev/`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,6 @@
   "commitMessagePrefix": "⬆️(project)",
   "commitMessageAction": "upgrade",
   "commitBodyTable": true,
-  "ignoreDeps": ["pydantic", "ipython", "pytest-httpx"],
+  "ignoreDeps": ["pydantic", "dev/ipython", "dev/pytest-httpx"],
   "dependencyDashboard": true
 }


### PR DESCRIPTION
The `ignoreDeps` configuration field allows you to define a list of dependency names to be ignored by Renovate. However, it supports only exact match dependency. As `ipython` and `pytest-httpx` are dev dependencies, renovate bot seems to prefix them with `dev/`. This fixes their ignored dependency names.