### PR TITLE
✨(frontend) Basic LTI rendering 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ yarn-error.log*
 *.tsbuildinfo
 vite-env.d.ts
 
+# build
+src/app/staticfiles/js
+
 # -- Environments
 .env
 .venv

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ WARREN_API_SERVER_PORT               ?= 8100
 WARREN_FRONTEND_IMAGE_NAME           ?= warren-frontend
 WARREN_FRONTEND_IMAGE_TAG            ?= development
 WARREN_FRONTEND_IMAGE_BUILD_TARGET   ?= development
-WARREN_FRONTEND_SERVER_PORT          ?= 3000
+WARREN_FRONTEND_IMAGE_BUILD_PATH     ?= app/staticfiles/js/build/assets/index.js
 
 
 # ==============================================================================
@@ -147,7 +147,7 @@ logs: ## display frontend/api logs (follow mode)
 .PHONY: logs
 
 run: ## run the whole stack
-run: run-frontend
+run: run-app
 .PHONY: run
 
 run-app: ## run the app server (development mode)
@@ -155,6 +155,7 @@ run-app: ## run the app server (development mode)
 	@echo "Waiting for the app to be up and running..."
 	@$(COMPOSE_RUN) dockerize -wait tcp://$(DB_HOST):$(DB_PORT) -timeout 60s
 	@$(COMPOSE_RUN) dockerize -wait tcp://app:$(WARREN_APP_SERVER_PORT) -timeout 60s
+	@$(COMPOSE_RUN) dockerize -wait file:///$(WARREN_FRONTEND_IMAGE_BUILD_PATH) -timeout 60s
 .PHONY: run-app
 
 run-api: ## run the api server (development mode)
@@ -164,13 +165,6 @@ run-api: ## run the api server (development mode)
 	@$(COMPOSE_RUN) dockerize -wait http://$(RALPH_COMPOSE_SERVICE):$(RALPH_RUNSERVER_PORT)/__heartbeat__ -timeout 60s
 	@$(COMPOSE_RUN) dockerize -wait tcp://api:$(WARREN_API_SERVER_PORT) -timeout 60s
 .PHONY: run-api
-
-run-frontend: ## run the frontend server (development mode)
-run-frontend: run-api
-	@$(COMPOSE) up -d frontend
-	@echo "Waiting for frontend to be up and running..."
-	@$(COMPOSE_RUN) dockerize -wait tcp://frontend:$(WARREN_FRONTEND_SERVER_PORT) -timeout 60s
-.PHONY: run-frontend
 
 status: ## an alias for "docker compose ps"
 	@$(COMPOSE) ps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,9 @@ services:
     volumes:
       - ./src/app:/app
     depends_on:
-      - "postgresql"
-      - "api"
+      - postgresql
+      - api
+      - frontend
 
   api:
     build:
@@ -67,14 +68,13 @@ services:
     image: "${WARREN_FRONTEND_IMAGE_NAME:-warren-frontend}:${WARREN_FRONTEND_IMAGE_TAG:-development}"
     environment:
       HOME: /tmp
-    ports:
-      - "${WARREN_FRONTEND_SERVER_PORT:-3000}:${WARREN_FRONTEND_SERVER_PORT:-3000}"
     command:
       - yarn
       - run
       - dev
     volumes:
       - ./src/frontend:/app
+      - ./src/app/staticfiles:/app/staticfiles
     depends_on:
       - api
 
@@ -110,6 +110,8 @@ services:
   # -- tools
   dockerize:
     image: jwilder/dockerize
+    volumes:
+      - ./src/app/staticfiles:/app/staticfiles
 
   notebook:
     build:

--- a/src/api/core/warren/conf.py
+++ b/src/api/core/warren/conf.py
@@ -42,7 +42,7 @@ class Settings(BaseSettings):
 
     # Security
     ALLOWED_HOSTS: List[str] = [
-        "http://localhost:3000",
+        "http://localhost:8090",
     ]
 
     # pylint: disable=invalid-name

--- a/src/app/apps/dashboards/templates/dashboards/base.html
+++ b/src/app/apps/dashboards/templates/dashboards/base.html
@@ -1,1 +1,14 @@
-Woot.
+{% load static %}
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="{% static 'js/build/assets/index.css' %}">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  </head>
+  <body>
+    <div id="warren-frontend-data" data-context="{{ app_data }}"></div>
+    <div id="warren-frontend-root"></div>
+    <script src='{% static "js/build/assets/index.js" %}'></script>
+  </body>
+</html>

--- a/src/app/apps/dashboards/views.py
+++ b/src/app/apps/dashboards/views.py
@@ -6,3 +6,11 @@ class DashboardView(TemplateView):
     """Dummy dashboard view."""
 
     template_name = "dashboards/base.html"
+
+    def _build_app_data(self):
+        return {"key": "woop."}
+
+    def get_context_data(self):
+        """Enrich view's context with app's data."""
+        parent_context = super().get_context_data()
+        return {"app_data": self._build_app_data(), **parent_context}

--- a/src/app/warren/settings.py
+++ b/src/app/warren/settings.py
@@ -1,6 +1,7 @@
 """Django settings for warren project."""
 
 import json
+import os
 from pathlib import Path
 from typing import List
 
@@ -118,7 +119,7 @@ class Base(Configuration):
     # Static files (CSS, JavaScript, Images)
     # https://docs.djangoproject.com/en/4.1/howto/static-files/
     STATIC_URL = "static/"
-    STATIC_ROOT = values.Value(BASE_DIR / "staticfiles")
+    STATICFILES_DIRS = [os.path.join(BASE_DIR, "staticfiles")]
 
     # Default primary key field type
     # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field

--- a/src/frontend/apps/web/index.html
+++ b/src/frontend/apps/web/index.html
@@ -7,7 +7,8 @@
     <title>Warren</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="warren-frontend-data" data-context="{}"></div>
+    <div id="#warren-frontend-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/frontend/apps/web/package.json
+++ b/src/frontend/apps/web/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "lint": "eslint . '**/*.{ts,tsx}'",
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "vite build --emptyOutDir --watch --mode development",
+    "build": "vite build --emptyOutDir",
     "build-theme": "cunningham -g css -o pages"
   },
   "dependencies": {

--- a/src/frontend/apps/web/src/App.tsx
+++ b/src/frontend/apps/web/src/App.tsx
@@ -3,8 +3,13 @@ import AppProvider from "ui/provider/app";
 import Filters from "ui/components/filters";
 import { DailyViews } from "ui";
 import Layout from "../components/Layout";
+import { parseDataContext } from "./utils";
+
+const dataContext = parseDataContext();
 
 export const App = () => {
+  // todo : store this data in a proper context and initialize the app
+  console.log(dataContext); // eslint-disable-line no-console
   return (
     <Layout>
       <AppProvider>

--- a/src/frontend/apps/web/src/main.tsx
+++ b/src/frontend/apps/web/src/main.tsx
@@ -1,10 +1,19 @@
 import React from "react";
-import ReactDOM from "react-dom/client";
+import { createRoot } from "react-dom/client";
 import "./index.scss";
 import { App } from "./App";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+document.addEventListener("DOMContentLoaded", () => {
+  const container = document.querySelector("#warren-frontend-root");
+
+  if (!container) {
+    throw new Error("container not found!");
+  }
+
+  const root = createRoot(container);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+});

--- a/src/frontend/apps/web/src/utils.ts
+++ b/src/frontend/apps/web/src/utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Extracts and parses JSON-formatted data embedded within a designated DOM element.
+ * The data is expected to be stored as a string within the `data-context` attribute of the element.
+ *
+ * @throws {Error} If the DOM element with id `warren-frontend-data` is not found.
+ * @throws {Error} If the `data-context` attribute is missing from the identified element.
+ * @throws {SyntaxError|TypeError} If errors occur during JSON parsing.
+ *
+ * @returns {any} Parsed JavaScript object representing the extracted data.
+ */
+export const parseDataContext = (): any => {
+  const element = document.getElementById("warren-frontend-data");
+
+  if (!element) {
+    throw new Error("`warren-frontend-data` is missing from DOM.");
+  }
+
+  const dataString = element.getAttribute("data-context");
+
+  if (!dataString) {
+    throw new Error("`app_data` is missing from DOM.");
+  }
+
+  // Sanitize the data string to match JSON requirements.
+  const dataStringSanitized = dataString.replaceAll("'", '"');
+  return JSON.parse(dataStringSanitized);
+};

--- a/src/frontend/apps/web/vite.config.ts
+++ b/src/frontend/apps/web/vite.config.ts
@@ -4,11 +4,13 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  server: {
-    host: true,
-    port: 3000,
-    hmr: {
-      port: 3001,
+  build: {
+    outDir: "../../../app/staticfiles/js/build",
+    rollupOptions: {
+      output: {
+        entryFileNames: `assets/[name].js`,
+        assetFileNames: `assets/[name].[ext]`,
+      },
     },
   },
 });


### PR DESCRIPTION
## Purpose

Integrate the Web app using the Django LTI server for rendering.

## Proposal

This has been influenced by Marsha's approach, but please keep in mind that this implementation is not yet finalized. Our upcoming plans involve substantial code refactoring to incorporate app routing and refine the initialization logic.

- [X] Output frontend build in Django static files.
- [X] Inject the JS bundle and stylesheet in Django base template.
- [X] Render the SPA in a dedicated div.
- [X] Implement data transmission to the frontend through the DOM.


#### Dev environment

Running `make run` would start the development server, namely the Django app. Then, you could access the frontend through two paths:

- The dashboard navigating through `http://localhost:8090/dashboards/`
- The development interface refined by @jmaupetit navigating through `http://localhost:8090/develoment/`.

#### Anticipated Improvements and Features:
In the upcoming iterations, we aspire to set up the frontend app initialization process and content loading. Our app's capabilities, while limited, will allow users to:

- Select specific resources (Dashboard or plot) through deep linking.
- Render a selected dashboard.
- Render a selected plot.

The forthcoming enhancements will set the bare minimum user interactions to play with Warren.
