### PR TITLE
✨(app) enable consumer access to LTI Provider Configurations

### DIFF
--- a/src/app/apps/lti/templates/config.xml
+++ b/src/app/apps/lti/templates/config.xml
@@ -1,0 +1,49 @@
+{% load static %}<?xml version="1.0" encoding="UTF-8"?>
+<cartridge_basiclti_link xmlns="http://www.imsglobal.org/xsd/imslticc_v1p0"
+    xmlns:blti = "http://www.imsglobal.org/xsd/imsbasiclti_v1p0"
+    xmlns:lticm ="http://www.imsglobal.org/xsd/imslticm_v1p0"
+    xmlns:lticp ="http://www.imsglobal.org/xsd/imslticp_v1p0"
+    xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation = "http://www.imsglobal.org/xsd/imslticc_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticc_v1p0.xsd
+    http://www.imsglobal.org/xsd/imsbasiclti_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0.xsd
+    http://www.imsglobal.org/xsd/imslticm_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd
+    http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
+    {% if title %}
+        <blti:title>{{ title }}</blti:title>
+    {% endif %}
+    {% if description %}
+        <blti:description>{{ description }}</blti:description>
+    {% endif %}
+    <blti:launch_url>http://{{ host }}</blti:launch_url>
+    <blti:secure_launch_url>https://{{ host }}</blti:secure_launch_url>
+
+    {% if icon_url %}
+        <blti:icon>http:{{ icon_url }}</blti:icon>
+        <blti:secure_icon>https:{{ icon_url }}</blti:secure_icon>
+    {% endif %}
+
+    {% if code or title or description or url or contact_email %}
+        <blti:vendor>
+            {% if code %}
+                <lticp:code>{{ code }}</lticp:code>
+            {% endif %}
+            {% if title %}
+                <lticp:name>{{ title }}</lticp:name>
+            {% endif %}
+            {% if description %}
+                <lticp:description>{{ description }}</lticp:description>
+            {% endif %}
+            {% if url %}
+                <lticp:url>{{ url }}</lticp:url>
+            {% endif %}
+            {% if contact_email %}
+                <lticp:contact>
+                    <lticp:email>{{ contact_email }}</lticp:email>
+                </lticp:contact>
+            {% endif %}
+        </blti:vendor>
+    {% endif %}
+
+    <cartridge_bundle identifierref="BLTI001_Bundle"/>
+    <cartridge_icon identifierref="BLTI001_Icon"/>
+</cartridge_basiclti_link>

--- a/src/app/apps/lti/urls.py
+++ b/src/app/apps/lti/urls.py
@@ -2,10 +2,11 @@
 
 from django.urls import path
 
-from .views import LTIRequestView
+from .views import LTIConfigView, LTIRequestView
 
 app_name = "lti"
 
 urlpatterns = [
     path("", LTIRequestView.as_view(), name="lti-request-view"),
+    path("config.xml", LTIConfigView.as_view(), name="lti-config-view"),
 ]

--- a/src/app/apps/lti/views.py
+++ b/src/app/apps/lti/views.py
@@ -2,9 +2,11 @@
 
 import logging
 
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
+from django.views.generic import TemplateView
 from lti_toolbox.exceptions import LTIException
 from lti_toolbox.lti import LTI
 from lti_toolbox.views import BaseLTIView
@@ -37,3 +39,30 @@ class LTIRequestView(BaseLTIView):
         """Raise an error when the LTI request fails."""
         logger.debug("LTI request failed with error: %s", error)
         raise PermissionDenied
+
+
+class LTIConfigView(TemplateView):
+    """Provide access to Warren LTI Provider Configurations for Consumers.
+
+    For instance, when configuring an LMS like Moodle, you have the ability to provide
+    a URL for the LTI tool configurations of the provider. This function returns an
+    XML containing a set of predefined LTI parameters that may need to be
+    overloaded manually.
+    """
+
+    template_name = "config.xml"
+    content_type = "text/xml; charset=utf-8"
+
+    def get_context_data(self, **kwargs):
+        """Get context data for rendering the template."""
+        return {
+            "code": settings.LTI_CONFIG_TITLE.lower()
+            if settings.LTI_CONFIG_TITLE
+            else None,
+            "contact_email": settings.LTI_CONFIG_CONTACT_EMAIL,
+            "description": settings.LTI_CONFIG_DESCRIPTION,
+            "host": self.request.get_host(),
+            "icon_url": settings.LTI_CONFIG_ICON,
+            "title": settings.LTI_CONFIG_TITLE,
+            "url": settings.LTI_CONFIG_URL,
+        }

--- a/src/app/warren/settings.py
+++ b/src/app/warren/settings.py
@@ -209,6 +209,16 @@ class Base(Configuration):
         {}, environ_name="EDX_PLATFORM_API_TOKENS", environ_prefix=None
     )
 
+    # LTI
+    LTI_CONFIG_TITLE = values.Value("Warren")
+    LTI_CONFIG_DESCRIPTION = values.Value(
+        "An opensource visualization platform for learning analytics."
+    )
+    # todo : update it with a favicon
+    LTI_CONFIG_ICON = values.Value()
+    LTI_CONFIG_URL = values.Value()
+    LTI_CONFIG_CONTACT_EMAIL = values.Value()
+
     @classmethod
     def post_setup(cls):
         """Post setup configuration.


### PR DESCRIPTION
## Purpose

This update offers for LTI consumers to access Warren's LTI configurations via a designated URL. The endpoint returns a set of predefined LTI parameters that can be customized as necessary when establishing the LTI connection within an LMS.


## Proposal

Please be aware that the URL for the icon might require updating once Warren obtains a logo.

- [X] Added a new template, `config.xml`.
- [X] Created a new LTI view, namely `LTIConfigView`.
- [X] Added a new route `lti/config.xml`.
- [X] Set some LTI config to the global Django settings.
