### PR TITLE
🚧 (api) Video : Completion threshold, Name, and Length

### DIFF
--- a/src/api/plugins/video/warren_video/api.py
+++ b/src/api/plugins/video/warren_video/api.py
@@ -7,7 +7,12 @@ from warren.backends import lrs_client
 from warren.fields import IRI
 from warren.filters import BaseQueryFilters, DatetimeRange
 from warren.models import DailyCounts
-from warren_video.indicators import DailyCompletedViews, DailyDownloads, DailyViews, Wip
+from warren_video.indicators import (
+    DailyCompletedViews,
+    DailyDownloads,
+    DailyViews,
+    Information,
+)
 from warren_video.models import Info
 
 router = APIRouter(
@@ -72,7 +77,7 @@ async def info(
     video_id: IRI,
 ) -> Info:
     """Wip."""
-    indicator = Wip(
+    indicator = Information(
         client=lrs_client,
         video_id=video_id,
     )

--- a/src/api/plugins/video/warren_video/api.py
+++ b/src/api/plugins/video/warren_video/api.py
@@ -7,7 +7,8 @@ from warren.backends import lrs_client
 from warren.fields import IRI
 from warren.filters import BaseQueryFilters, DatetimeRange
 from warren.models import DailyCounts
-from warren_video.indicators import DailyCompletedViews, DailyDownloads, DailyViews
+from warren_video.indicators import DailyCompletedViews, DailyDownloads, DailyViews, Wip
+from warren_video.models import Info
 
 router = APIRouter(
     prefix="/video",
@@ -62,5 +63,23 @@ async def downloads(
         return await indicator.compute()
     except (KeyError, AttributeError) as exception:
         message = "An error occurred while computing the number of downloads"
+        logger.error("%s: %s", message, exception)
+        raise HTTPException(status_code=500, detail=message) from exception
+
+
+@router.get("/{video_id:path}/info")
+async def info(
+    video_id: IRI,
+) -> Info:
+    """Wip."""
+    indicator = Wip(
+        client=lrs_client,
+        video_id=video_id,
+    )
+    try:
+        return await indicator.compute()
+    # todo - specify this exception handling
+    except Exception as exception:
+        message = "An error occurred while computing the information"
         logger.error("%s: %s", message, exception)
         raise HTTPException(status_code=500, detail=message) from exception

--- a/src/api/plugins/video/warren_video/factories.py
+++ b/src/api/plugins/video/warren_video/factories.py
@@ -124,7 +124,7 @@ class VideoDownloadedFactory(BaseXapiStatementFactory):
         },
         "timestamp": "2021-12-01T08:17:47.150905+00:00",
     }
-    model: VideoPlayed = VideoDownloaded
+    model: VideoDownloaded = VideoDownloaded
 
 
 class VideoInitializedFactory(BaseXapiStatementFactory):

--- a/src/api/plugins/video/warren_video/factories.py
+++ b/src/api/plugins/video/warren_video/factories.py
@@ -1,6 +1,10 @@
 """Factories for video xAPI events."""
 from ralph.models.xapi.concepts.constants.video import RESULT_EXTENSION_TIME
-from ralph.models.xapi.video.statements import VideoDownloaded, VideoPlayed
+from ralph.models.xapi.video.statements import (
+    VideoDownloaded,
+    VideoInitialized,
+    VideoPlayed,
+)
 from warren.factories.base import BaseXapiStatementFactory
 
 
@@ -121,3 +125,63 @@ class VideoDownloadedFactory(BaseXapiStatementFactory):
         "timestamp": "2021-12-01T08:17:47.150905+00:00",
     }
     model: VideoPlayed = VideoDownloaded
+
+
+class VideoInitializedFactory(BaseXapiStatementFactory):
+    """VideoInitialized xAPI statement factory."""
+
+    template: dict = {
+        "verb": {
+            "id": "http://adlnet.gov/expapi/verbs/initialized",
+            "display": {"en-US": "initialized"},
+        },
+        "context": {
+            "extensions": {
+                "https://w3id.org/xapi/video/extensions/session-id": (
+                    "1be53154-aed0-5aab-9485-b773e7efaf24"
+                ),
+                "https://w3id.org/xapi/video/extensions/length": 480,
+                "https://w3id.org/xapi/video/extensions/completion-threshold": 0.9,
+            },
+            "contextActivities": {
+                "category": [
+                    {
+                        "id": "https://w3id.org/xapi/video",
+                        "definition": {
+                            "id": "uuid://C678149d-956a-483d-8975-c1506de1e1a9",
+                            "definition": {
+                                "type": "http://adlnet.gov/expapi/activities/profile"
+                            },
+                        },
+                    }
+                ],
+                "parent": [
+                    {
+                        "id": "course-v1:FUN-MOOC+00001+session01",
+                        "objectType": "Activity",
+                        "definition": {
+                            "type": "http://adlnet.gov/expapi/activities/course"
+                        },
+                    }
+                ],
+            },
+        },
+        "id": "2140967b-563b-464b-90c0-2e114bd8e133",
+        "actor": {
+            "objectType": "Agent",
+            "account": {
+                "name": "d5b3733b-ccd9-4ab1-bb29-22e3c2f2e592",
+                "homePage": "http://lms.example.org",
+            },
+        },
+        "object": {
+            "definition": {
+                "type": "https://w3id.org/xapi/video/activity-type/video",
+                "name": {"en-US": "Learning analytics 101"},
+            },
+            "id": "uuid://dd38149d-956a-483d-8975-c1506de1e1a9",
+            "objectType": "Activity",
+        },
+        "timestamp": "2021-12-01T08:17:47.150905+00:00",
+    }
+    model: VideoInitialized = VideoInitialized

--- a/src/api/plugins/video/warren_video/indicators.py
+++ b/src/api/plugins/video/warren_video/indicators.py
@@ -168,20 +168,37 @@ class DailyDownloads(BaseDailyEvent):
     verb_id = DownloadedVerb().id
 
 
-class Wip(BaseIndicator, PreprocessMixin):
+class Information(BaseIndicator, PreprocessMixin):
+    """Information Indicator.
+
+    Extract static information for a video from `Initialized` statements.
+
+    Inherit from BaseDailyEvent, which provides functionality for calculating
+    indicators based on different xAPI verbs.
+    """
 
     def __init__(
         self,
         client: BaseHTTP,
         video_id: str,
     ):
+        """Instantiate the Static Information Indicator.
+
+        Args:
+            client (BaseHTTP): The LRS backend to query.
+            video_id: The ID of the video on which to compute the metric
+        """
         self.client = client
         self.video_id = video_id
 
     def get_lrs_query(
         self,
     ) -> LRSQuery:
-        """Get the LRS query for fetching required statements."""
+        """Get the LRS query for fetching required statements.
+
+        'Initialized' statements are enough to extract any static
+        information of a video.
+        """
         return LRSQuery(
             query={
                 "activity": self.video_id,
@@ -203,6 +220,13 @@ class Wip(BaseIndicator, PreprocessMixin):
         self.raw_statements = self.raw_statements.sample(3)
 
     async def compute(self) -> Info:
+        """Fetch statements and compute the current indicator.
+
+        Fetch statements from LRS, parse them, and extract static video information.
+        Since not all statements are guaranteed to be initialized correctly, we enhance
+        reliability by determining the most common value for each static info, and using
+        the first one arbitrarily.
+        """
         await self.fetch_statements()
 
         if not self.raw_statements:

--- a/src/api/plugins/video/warren_video/models.py
+++ b/src/api/plugins/video/warren_video/models.py
@@ -3,29 +3,10 @@ from typing import Union
 
 from pydantic import BaseModel, validator
 
-Seconds = Union[int, None]
-Percent = Union[float, None]
-
 
 class Info(BaseModel):
     """Base model to represent information for a video."""
 
     name: str | None
-    length: Seconds
-    completion_threshold: Percent
-
-    @validator("length")
-    @classmethod
-    def length_must_be_positive(cls, v: Seconds) -> Seconds:
-        """Validate video's length."""
-        if v is not None and v < 0:
-            raise ValueError("must be positive.")
-        return v
-
-    @validator("completion_threshold")
-    @classmethod
-    def completion_threshold_must_be_valid(cls, v: Percent) -> Percent:
-        """Validate video's completion threshold."""
-        if v is not None and (v < 0 or v > 1):
-            raise ValueError("must be between 0 and 1.")
-        return v
+    length: Union[PositiveInt, None]  # in Seconds
+    completion_threshold: Union[confloat(gt=0.0, lt=1.0), None]  # in Percent

--- a/src/api/plugins/video/warren_video/models.py
+++ b/src/api/plugins/video/warren_video/models.py
@@ -1,4 +1,5 @@
 """Defines the schema of what is returned inside the API responses."""
+from typing import Union
 
 from pydantic import BaseModel, validator
 
@@ -7,6 +8,8 @@ Percent = Union[float, None]
 
 
 class Info(BaseModel):
+    """Base model to represent information for a video."""
+
     name: str | None
     length: Seconds
     completion_threshold: Percent
@@ -14,6 +17,7 @@ class Info(BaseModel):
     @validator("length")
     @classmethod
     def length_must_be_positive(cls, v: Seconds) -> Seconds:
+        """Validate video's length."""
         if v is not None and v < 0:
             raise ValueError("must be positive.")
         return v
@@ -21,6 +25,7 @@ class Info(BaseModel):
     @validator("completion_threshold")
     @classmethod
     def completion_threshold_must_be_valid(cls, v: Percent) -> Percent:
+        """Validate video's completion threshold."""
         if v is not None and (v < 0 or v > 1):
             raise ValueError("must be between 0 and 1.")
         return v

--- a/src/api/plugins/video/warren_video/models.py
+++ b/src/api/plugins/video/warren_video/models.py
@@ -1,1 +1,26 @@
 """Defines the schema of what is returned inside the API responses."""
+
+from pydantic import BaseModel, validator
+
+Seconds = int | None
+Percent = float | None
+
+
+class Info(BaseModel):
+    name: str | None
+    length: Seconds
+    completion_threshold: Percent
+
+    @validator("length")
+    @classmethod
+    def length_must_be_positive(cls, v: Seconds) -> Seconds:
+        if v is not None and v < 0:
+            raise ValueError("must be positive.")
+        return v
+
+    @validator("completion_threshold")
+    @classmethod
+    def completion_threshold_must_be_valid(cls, v: Percent) -> Percent:
+        if v is not None and (v < 0 or v > 1):
+            raise ValueError("must be between 0 and 1.")
+        return v

--- a/src/api/plugins/video/warren_video/models.py
+++ b/src/api/plugins/video/warren_video/models.py
@@ -2,8 +2,8 @@
 
 from pydantic import BaseModel, validator
 
-Seconds = int | None
-Percent = float | None
+Seconds = Union[int, None]
+Percent = Union[float, None]
 
 
 class Info(BaseModel):


### PR DESCRIPTION
## Purpose

Exposes metadata of a given video resource.

## Proposal

Create a new endpoint `/info`, that returns video's metadata from `Initialized` statements.

- [X] Create a new Pydantic model to represent these data.
- [X] Create a new Indicator (name and inheritance to be discussed).
- [ ] Fetch relevant Initialized statements (still need to put a limit on the max number of statements queried).
- [ ] Filter statements to be discussed.
- [x] Add tests on the new endpoint.
- [x] Add documentation to the new indicator and Pydantic model.
- [ ] Improve exception handling on the new endpoint.

