### PR TITLE
👷(ci) harmonize CI linting rules with local development guidelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,6 @@ jobs:
     working_directory: ~/fun
     steps:
       - checkout
-      # Make sure the changes don't add a "print" statement to the code base.
-      # We should exclude the ".circleci" folder from the search as the very command that checks
-      # the absence of "print" is including a "print(" itself.
-      - run:
-          name: enforce absence of print statements in code
-          command: |
-            ! git diff origin/main..HEAD -- . ':(exclude).circleci' | grep "print("
       - run:
           name: Check absence of fixup commits
           command: |

--- a/src/api/core/pyproject.toml
+++ b/src/api/core/pyproject.toml
@@ -92,6 +92,7 @@ select = [
     "PLW",  # Pylint Warning
     "RUF100",  # Ruff unused-noqa
     "S",  # flake8-bandit
+    "T20", # flake8-print
     "W",  # pycodestyle warning
 ]
 

--- a/src/app/pyproject.toml
+++ b/src/app/pyproject.toml
@@ -88,6 +88,7 @@ select = [
     "PLW",  # Pylint Warning
     "RUF100",  # Ruff unused-noqa
     "S",  # flake8-bandit
+    "T20", # flake8-print
     "W",  # pycodestyle warning
 ]
 exclude = ["apps/*/migrations/*"]


### PR DESCRIPTION
## Purpose

Check for print statements in the `make lint` command instead of the `lint-git` job.

## Proposal

The `lint-git` CI job might not be the optimal location for examining print statements, as this is more aligned with the responsibility of our linter. Moreover, the inspection of print statements is language-specific and should pertain only to jobs running on Python files. `lint-git` is running both on python and JavaScript files.

- [x] Remove print check from lint-git CI job.
- [x] Enable print check in ruff linter.
