### PR TITLE
🔨(frontend) drop redundant steps for building the frontend image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,6 @@ build-docker-frontend: .env
 	WARREN_FRONTEND_IMAGE_NAME=$(WARREN_FRONTEND_IMAGE_NAME) \
 	WARREN_FRONTEND_IMAGE_TAG=$(WARREN_FRONTEND_IMAGE_TAG) \
 	  $(COMPOSE) build frontend
-	@$(COMPOSE_RUN_FRONTEND) yarn install
 .PHONY: build-docker-frontend
 
 build-frontend: ## build the frontend application


### PR DESCRIPTION
## Purpose

Simplify the frontend image build.

## Proposal

Avoid redundant `yarn install` steps.

Duplicated `yarn install` between the Dockerfile `Build` section, and the Makefile command `build-docker-frontend` have been fixed.

Dependencies should be installed only once. It wasn't an issue as `yarn install` would use cached dependencies, when called twice.
