### PR TITLE
🥅 (api) catch BackendException from the LRS client

### DIFF
--- a/src/api/core/warren/exceptions.py
+++ b/src/api/core/warren/exceptions.py
@@ -1,0 +1,5 @@
+"""Exceptions for warren."""
+
+
+class LrsClientException(Exception):
+    """Raised when the LRS client has a failure."""

--- a/src/api/plugins/video/warren_video/api.py
+++ b/src/api/plugins/video/warren_video/api.py
@@ -4,6 +4,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 from typing_extensions import Annotated  # python <3.9 compat
 from warren.backends import lrs_client
+from warren.exceptions import LrsClientException
 from warren.fields import IRI
 from warren.filters import BaseQueryFilters, DatetimeRange
 from warren.models import DailyCounts
@@ -38,7 +39,7 @@ async def views(
 
     try:
         return await indicator.compute()
-    except (KeyError, AttributeError) as exception:
+    except (KeyError, AttributeError, LrsClientException) as exception:
         message = "An error occurred while computing the number of views"
         logger.error("%s: %s", message, exception)
         raise HTTPException(status_code=500, detail=message) from exception
@@ -60,7 +61,7 @@ async def downloads(
 
     try:
         return await indicator.compute()
-    except (KeyError, AttributeError) as exception:
+    except (KeyError, AttributeError, LrsClientException) as exception:
         message = "An error occurred while computing the number of downloads"
         logger.error("%s: %s", message, exception)
         raise HTTPException(status_code=500, detail=message) from exception


### PR DESCRIPTION
LRS client exceptions were not being handled correctly, resulting in API server failures.

To fix this issue, we created a custom `ClientException` class, and implement error handling for it in all API routes responsible for computing indicators by fetching statements.
