### PR TITLE
🛂(app) limit deep-linking access to 'read-write-configure' LTI role

### DIFF
--- a/src/app/apps/lti/views.py
+++ b/src/app/apps/lti/views.py
@@ -145,6 +145,10 @@ class LTISelectView(BaseLTIView, RenderMixins):
             logger.debug("LTI message type is not valid")
             raise PermissionDenied
 
+        if not lti_request.can_edit_content:
+            logger.debug("LTI role is not valid")
+            raise PermissionDenied
+
         lti_select_form_data["lti_message_type"] = LTIMessageType.SELECTION_RESPONSE
 
         # todo - sign lti_select_form_data with an access token.


### PR DESCRIPTION

## Purpose

Limit the Content-Item Selection view to a user with a `read-write-configure` role, e.g. `instructor` or `admin`. 

For example, a `student` does not have permissions to select content through deep-linking, but they can render selected content. 

It closes #89.