### PR TITLE
🎨(api) import FastAPI HTTP status constants to avoid hardcoding integer values

### DIFF
--- a/src/api/core/warren/filters.py
+++ b/src/api/core/warren/filters.py
@@ -1,7 +1,7 @@
 """Warren API filters."""
 
 import arrow
-from fastapi import HTTPException
+from fastapi import HTTPException, status
 from pydantic import BaseModel, ValidationError, root_validator
 
 from .conf import settings
@@ -65,7 +65,9 @@ class BaseQueryFilters(DatetimeRange):
         except ValidationError as err:
             for error in err.errors():
                 error["loc"] = ["query"] + list(error["loc"])
-            raise HTTPException(422, detail=err.errors()) from err
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_ENTITY, detail=err.errors()
+            ) from err
         return values
 
     @root_validator
@@ -74,5 +76,8 @@ class BaseQueryFilters(DatetimeRange):
         """Check that date/time range is not too greedy."""
         since, until = map(values.get, ["since", "until"])
         if since + settings.MAX_DATETIMERANGE_SPAN < until:
-            raise HTTPException(422, detail="Date/time range is too greedy.")
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Date/time range is too greedy.",
+            )
         return values

--- a/src/api/plugins/video/warren_video/api.py
+++ b/src/api/plugins/video/warren_video/api.py
@@ -1,7 +1,7 @@
 """Warren API v1 video router."""
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from typing_extensions import Annotated  # python <3.9 compat
 from warren.exceptions import LrsClientException
 from warren.fields import IRI
@@ -40,7 +40,9 @@ async def views(
     except (KeyError, AttributeError, LrsClientException) as exception:
         message = "An error occurred while computing the number of views"
         logger.error("%s: %s", message, exception)
-        raise HTTPException(status_code=500, detail=message) from exception
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message
+        ) from exception
 
 
 @router.get("/{video_id:path}/downloads")
@@ -61,4 +63,6 @@ async def downloads(
     except (KeyError, AttributeError, LrsClientException) as exception:
         message = "An error occurred while computing the number of downloads"
         logger.error("%s: %s", message, exception)
-        raise HTTPException(status_code=500, detail=message) from exception
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message
+        ) from exception


### PR DESCRIPTION
`HTTPException` statuses were previously hard-coded with integer values. Importing Fast API constants, we not only enhance the maintainability of this logic, but also provide explicit names for each status code. Under the hood, These constants are imported from the `starlette` package. Please find all constants [here](https://github.com/encode/starlette/blob/master/starlette/status.py)

