### PR TITLE
👷(circle) move to a single docker image name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,14 +119,20 @@ jobs:
       # Each image is tagged with the current git commit sha1 to avoid
       # collisions in parallel builds.
       - run:
-          name: Build production image
+          name: Build core production image
           command: |
-            WARREN_API_IMAGE_BUILD_TARGET=production \
-            WARREN_API_IMAGE_TAG=${CIRCLE_SHA1} \
+            WARREN_API_IMAGE_BUILD_TARGET=production-core \
+            WARREN_API_IMAGE_TAG=api-core-${CIRCLE_SHA1} \
+              make build-docker-api
+      - run:
+          name: Build full production image
+          command: |
+            WARREN_API_IMAGE_BUILD_TARGET=production-full \
+            WARREN_API_IMAGE_TAG=api-full-${CIRCLE_SHA1} \
               make build-docker-api
       - run:
           name: Check built image availability
-          command: docker images "warren-api:${CIRCLE_SHA1}*"
+          command: docker images "warren:api-*"
 
   build-docker-app:
     docker:
@@ -150,11 +156,11 @@ jobs:
           name: Build production image
           command: |
             WARREN_APP_IMAGE_BUILD_TARGET=production \
-            WARREN_APP_IMAGE_TAG=${CIRCLE_SHA1} \
+            WARREN_APP_IMAGE_TAG=app-${CIRCLE_SHA1} \
               make build-docker-app
       - run:
           name: Check built image availability
-          command: docker images "warren-app:${CIRCLE_SHA1}*"
+          command: docker images "warren:app-*"
 
   # ---- API jobs ----
   # Build API development environment
@@ -466,17 +472,26 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Build production image
+          name: Build APP production image
           command: |
             WARREN_APP_IMAGE_BUILD_TARGET=production \
-            WARREN_APP_IMAGE_TAG=${CIRCLE_SHA1} \
+            WARREN_APP_IMAGE_TAG=app-${CIRCLE_SHA1} \
               make build-docker-app
-            WARREN_API_IMAGE_BUILD_TARGET=production \
-            WARREN_API_IMAGE_TAG=${CIRCLE_SHA1} \
+      - run:
+          name: Build API core production image
+          command: |
+            WARREN_API_IMAGE_BUILD_TARGET=production-core \
+            WARREN_API_IMAGE_TAG=api-core-${CIRCLE_SHA1} \
+              make build-docker-api
+      - run:
+          name: Build API full production image
+          command: |
+            WARREN_API_IMAGE_BUILD_TARGET=production-full \
+            WARREN_API_IMAGE_TAG=api-full-${CIRCLE_SHA1} \
               make build-docker-api
       - run:
           name: Check built image availability
-          command: docker images "warren-ap*:${CIRCLE_SHA1}*"
+          command: docker images "warren:*"
       # Tag docker images with the same pattern used in Git (Semantic Versioning)
       #
       # Git tag: v1.0.1
@@ -492,13 +507,15 @@ jobs:
             # or
             # - DOCKER_TAG: 1.1.2 (Git tag v1.1.2)
             echo "DOCKER_TAG: ${DOCKER_TAG} (Git ${RELEASE_TYPE}${CIRCLE_TAG})"
-            docker tag warren-app:${CIRCLE_SHA1} fundocker/warren-app:${DOCKER_TAG}
-            docker tag warren-api:${CIRCLE_SHA1} fundocker/warren-api:${DOCKER_TAG}
+            docker tag warren:app-${CIRCLE_SHA1} fundocker/warren:app-${DOCKER_TAG}
+            docker tag warren:api-core-${CIRCLE_SHA1} fundocker/warren:api-core-${DOCKER_TAG}
+            docker tag warren:api-full-${CIRCLE_SHA1} fundocker/warren:api-full-${DOCKER_TAG}
             if [[ -n "$CIRCLE_TAG" ]]; then
-                docker tag warren-app:${CIRCLE_SHA1} fundocker/warren-app:latest
-                docker tag warren-api:${CIRCLE_SHA1} fundocker/warren-api:latest
+                docker tag warren:app-${CIRCLE_SHA1} fundocker/warren:app-latest
+                docker tag warren:api-core-${CIRCLE_SHA1} fundocker/warren:api-core-latest
+                docker tag warren:api-full-${CIRCLE_SHA1} fundocker/warren:api-full-latest
             fi
-            docker images "fundocker/warren-ap*"
+            docker images "fundocker/warren:*"
 
       # Publish images to DockerHub
       #
@@ -515,11 +532,13 @@ jobs:
             # or
             # - DOCKER_TAG: 1.1.2 (Git tag v1.1.2)
             echo "DOCKER_TAG: ${DOCKER_TAG} (Git ${RELEASE_TYPE}${CIRCLE_TAG})"
-            docker push fundocker/warren-app:${DOCKER_TAG}
-            docker push fundocker/warren-api:${DOCKER_TAG}
+            docker push fundocker/warren:app-${DOCKER_TAG}
+            docker push fundocker/warren:api-core-${DOCKER_TAG}
+            docker push fundocker/warren:api-full-${DOCKER_TAG}
             if [[ -n "$CIRCLE_TAG" ]]; then
-              docker push fundocker/warren-app:latest
-              docker push fundocker/warren-api:latest
+              docker push fundocker/warren:app-latest
+              docker push fundocker/warren:api-core-latest
+              docker push fundocker/warren:api-full-latest
             fi
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -33,17 +33,17 @@ DB_HOST = postgresql
 DB_PORT = 5432
 
 # -- Warren
-WARREN_APP_IMAGE_NAME              ?= warren-app
-WARREN_APP_IMAGE_TAG               ?= development
+WARREN_APP_IMAGE_NAME              ?= warren
+WARREN_APP_IMAGE_TAG               ?= app-development
 WARREN_APP_IMAGE_BUILD_TARGET      ?= development
 WARREN_APP_SERVER_PORT             ?= 8090
-WARREN_API_IMAGE_NAME              ?= warren-api
-WARREN_API_IMAGE_TAG               ?= development
+WARREN_API_IMAGE_NAME              ?= warren
+WARREN_API_IMAGE_TAG               ?= api-development
 WARREN_API_IMAGE_BUILD_TARGET      ?= development
 WARREN_API_SERVER_PORT             ?= 8100
 WARREN_API_TEST_DB_NAME            ?= test-warren-api
-WARREN_FRONTEND_IMAGE_NAME         ?= warren-frontend
-WARREN_FRONTEND_IMAGE_TAG          ?= development
+WARREN_FRONTEND_IMAGE_NAME         ?= warren
+WARREN_FRONTEND_IMAGE_TAG          ?= frontend-development
 WARREN_FRONTEND_IMAGE_BUILD_TARGET ?= development
 WARREN_FRONTEND_IMAGE_BUILD_PATH   ?= app/staticfiles/js/build/assets/index.js
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       args:
         DOCKER_USER: ${DOCKER_USER:-1000}
     user: ${DOCKER_USER:-1000}
-    image: "${WARREN_APP_IMAGE_NAME:-warren-app}:${WARREN_APP_IMAGE_TAG:-development}"
+    image: "${WARREN_APP_IMAGE_NAME:-warren}:${WARREN_APP_IMAGE_TAG:-app-development}"
     environment:
       PYLINTHOME: /app/.pylint.d
     env_file:
@@ -34,7 +34,7 @@ services:
       args:
         DOCKER_USER: ${DOCKER_USER:-1000}
     user: ${DOCKER_USER:-1000}
-    image: "${WARREN_API_IMAGE_NAME:-warren-api}:${WARREN_API_IMAGE_TAG:-development}"
+    image: "${WARREN_API_IMAGE_NAME:-warren}:${WARREN_API_IMAGE_TAG:-api-development}"
     env_file:
       - .env
     environment:
@@ -66,7 +66,7 @@ services:
       args:
         DOCKER_USER: ${DOCKER_USER:-1000}
     user: ${DOCKER_USER:-1000}
-    image: "${WARREN_FRONTEND_IMAGE_NAME:-warren-frontend}:${WARREN_FRONTEND_IMAGE_TAG:-development}"
+    image: "${WARREN_FRONTEND_IMAGE_NAME:-warren}:${WARREN_FRONTEND_IMAGE_TAG:-frontend-development}"
     environment:
       HOME: /tmp
     command:

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && \
 
 
 # -- Builder --
-FROM base as builder
+# Core builder (no plugins installed)
+FROM base as core-builder
 
 WORKDIR /build
 
@@ -25,21 +26,31 @@ RUN apt-get update && \
         libffi-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install ./core ./plugins/*
+RUN pip install ./core
+
+# Full distro builder (all official plugins installed)
+FROM core-builder as full-builder
+
+RUN pip install ./plugins/*
 
 # -- Core --
 FROM base as core
 
-COPY --from=builder /usr/local /usr/local
+COPY --from=core-builder /usr/local /usr/local
 
 # Copy all sources, not only runtime-required files
 COPY . /app/
 
 WORKDIR /app
 
+# -- Full --
+FROM core as full
+
+COPY --from=full-builder /usr/local /usr/local
+
 
 # -- Development --
-FROM core as development
+FROM full as development
 
 # Uninstall warren and re-install it in editable mode along with development
 # dependencies
@@ -55,7 +66,24 @@ USER ${DOCKER_USER:-1000}
 
 
 # -- Production --
-FROM core as production
+# *** Core image ***
+FROM core as production-core
+
+# Un-privileged user running the application
+USER ${DOCKER_USER:-1000}
+
+CMD ["uvicorn", \
+     "warren.api:app", \
+     "--proxy-headers", \
+     "--log-config", \
+     "core/logging-config.yaml", \
+     "--host", \
+     "0.0.0.0", \
+     "--port", \
+     "8000"]
+
+# *** Full image ***
+FROM full as production-full
 
 # Un-privileged user running the application
 USER ${DOCKER_USER:-1000}


### PR DESCRIPTION
## Purpose

All docker images required to run Warren will be called `warren` and we distinguish application services by their image tag.

## Proposal

- `warren:app-latest` is the latest warren app service
- `warren:api-core-latest` is the latest warren api service (core version)
- `warren:api-full-latest` is the latest warren api service (full version, i.e. with all official plugins installed)

`latest` points to the latest release, but each version tag will also be published (e.g. `warren:app-0.1.0`, `warren:api-core-0.1.0`, `warren:api-full-0.1.0`).

Docker images repository: https://hub.docker.com/repository/docker/fundocker/warren/general
