### PR TITLE
📦️(app) bundle the frontend app build in the staticfiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,11 +135,9 @@ jobs:
           command: docker images "warren:api-*"
 
   build-docker-app:
-    docker:
-      - image: cimg/base:current
-        auth:
-          username: $DOCKER_HUB_USER
-          password: $DOCKER_HUB_PASSWORD
+    machine:
+      image: ubuntu-2204:2023.07.2
+      docker_layer_caching: true
     working_directory: ~/fun
     steps:
       # Checkout repository sources
@@ -147,9 +145,6 @@ jobs:
       # Generate a version.json file describing app release & login to DockerHub
       - *generate-version-file
       - *docker-login
-      # Activate docker-in-docker (with layers caching enabled)
-      - setup_remote_docker:
-          docker_layer_caching: true
       # Each image is tagged with the current git commit sha1 to avoid
       # collisions in parallel builds.
       - run:
@@ -157,6 +152,7 @@ jobs:
           command: |
             WARREN_APP_IMAGE_BUILD_TARGET=production \
             WARREN_APP_IMAGE_TAG=app-${CIRCLE_SHA1} \
+            WARREN_FRONTEND_IMAGE_BUILD_TARGET=production \
               make build-docker-app
       - run:
           name: Check built image availability

--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,7 @@ yarn-error.log*
 vite-env.d.ts
 
 # build
-src/app/staticfiles/js
+src/app/staticfiles/warren
 
 # -- Environments
 .env

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ WARREN_API_TEST_DB_NAME            ?= test-warren-api
 WARREN_FRONTEND_IMAGE_NAME         ?= warren
 WARREN_FRONTEND_IMAGE_TAG          ?= frontend-development
 WARREN_FRONTEND_IMAGE_BUILD_TARGET ?= development
-WARREN_FRONTEND_IMAGE_BUILD_PATH   ?= app/staticfiles/js/build/assets/index.js
+WARREN_FRONTEND_IMAGE_BUILD_PATH   ?= app/staticfiles/warren/assets/index.js
 
 
 # ==============================================================================
@@ -92,7 +92,7 @@ bootstrap: \
   data/statements.jsonl.gz \
   build \
   migrate-api \
-	create-api-test-db \
+  create-api-test-db \
   migrate-app \
   fixtures
 .PHONY: bootstrap
@@ -105,7 +105,10 @@ build: \
 .PHONY: build
 
 build-docker-app: ## build the app container
-build-docker-app: .env
+build-docker-app: \
+  .env \
+  build-docker-frontend \
+  build-frontend
 	WARREN_APP_IMAGE_BUILD_TARGET=$(WARREN_APP_IMAGE_BUILD_TARGET) \
 	WARREN_APP_IMAGE_NAME=$(WARREN_APP_IMAGE_NAME) \
 	WARREN_APP_IMAGE_TAG=$(WARREN_APP_IMAGE_TAG) \

--- a/src/app/Dockerfile
+++ b/src/app/Dockerfile
@@ -32,6 +32,14 @@ COPY --from=builder /install /usr/local
 # Copy runtime-required files
 COPY . /app/
 
+# Clean up frontend static files
+# Nota bene: it requires that the frontend application to be already built
+RUN rm -fr /app/staticfiles/warren/* && mkdir -p /app/staticfiles/warren/assets/
+COPY ./staticfiles/warren/assets/index.js \
+        ./staticfiles/warren/assets/index-*.js \
+        ./staticfiles/warren/assets/index.css \
+        /app/staticfiles/warren/assets/
+
 # Prepare production run using gunicorn
 RUN mkdir -p /usr/local/etc/gunicorn
 COPY ./docker/files/usr/local/etc/gunicorn/warren.py /usr/local/etc/gunicorn/warren.py

--- a/src/app/apps/lti/templates/base.html
+++ b/src/app/apps/lti/templates/base.html
@@ -3,12 +3,12 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" type="text/css" href="{% static 'js/build/assets/index.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'warren/assets/index.css' %}">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
   </head>
   <body>
     <div id="warren-frontend-data" data-context="{{ app_data }}"></div>
     <div id="warren-frontend-root"></div>
-    <script type="module" src='{% static "js/build/assets/index.js" %}'></script>
+    <script type="module" src='{% static "warren/assets/index.js" %}'></script>
   </body>
 </html>

--- a/src/frontend/apps/web/vite.config.ts
+++ b/src/frontend/apps/web/vite.config.ts
@@ -5,7 +5,7 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   build: {
-    outDir: "../../../app/staticfiles/js/build",
+    outDir: "../../../app/staticfiles/warren/",
     rollupOptions: {
       output: {
         entryFileNames: `assets/[name].js`,


### PR DESCRIPTION
## Purpose

Warren `app` service requires the frontend build to work, and it is not bundled in the `warren:app` Docker image.

## Proposal

Frontend application build is now a requirement to build the `app` service Docker image.
