### PR TITLE
🧑‍💻(api) enforce the declaration of 'verb_id' in all video indicators

### DIFF
--- a/src/api/plugins/video/tests/test_indicators.py
+++ b/src/api/plugins/video/tests/test_indicators.py
@@ -1,0 +1,21 @@
+"""Tests for the video indicators."""
+
+import pytest
+from warren_video.indicators import BaseDailyEvent
+
+
+@pytest.mark.anyio
+async def test_base_daily_event_subclass_verb_id():
+    """Test __init_subclass__ for the BaseDailyEvent class."""
+
+    class MyIndicator(BaseDailyEvent):
+        verb_id = "test"
+
+    # the __init_subclass__ is called when the class itself is constructed.
+    # It should raise an error because the 'verb_id' class attribute is missing.
+    with pytest.raises(TypeError) as exception:
+
+        class MyIndicatorMissingAttribute(BaseDailyEvent):
+            wrong_attribute = "test"
+
+    assert str(exception.value) == "Indicators must declare a 'verb_id' class attribute"

--- a/src/api/plugins/video/warren_video/indicators.py
+++ b/src/api/plugins/video/warren_video/indicators.py
@@ -20,6 +20,9 @@ class BaseDailyEvent(BaseIndicator):
     This class defines a base daily event indicator. Given an event type, a video,
     and a date range, it calculates the total number of events and the number
     of events per day.
+
+    Required: Indicators inheriting from this base class must declare a 'verb_id'
+    class attribute with their xAPI verb ID.
     """
 
     def __init__(
@@ -41,6 +44,12 @@ class BaseDailyEvent(BaseIndicator):
         self.unique = unique
         self.video_id = video_id
         self.date_range = date_range
+
+    def __init_subclass__(cls, **kwargs):
+        """Ensure subclasses have a 'verb_id' class attribute."""
+        super().__init_subclass__(**kwargs)
+        if not hasattr(cls, "verb_id"):
+            raise TypeError("Indicators must declare a 'verb_id' class attribute")
 
     def get_lrs_query(
         self,


### PR DESCRIPTION
Added a missing check while constructing subclasses of `BaseDailyEvent`.
Improved the documentation on declaring new indicators that inherit from `BaseDailyEvent`.

These two additions should enhance the DX while using `BaseDailyEvent`.