### PR TITLE
Cache video indicators

### DIFF
--- a/src/api/core/warren/db.py
+++ b/src/api/core/warren/db.py
@@ -1,7 +1,13 @@
 """Warren persistence database connection."""
 
-from sqlmodel import create_engine
+from sqlmodel import Session, create_engine
 
 from .conf import settings
 
 engine = create_engine(settings.DATABASE_URL, echo=settings.DEBUG)
+
+
+def get_session() -> Session:
+    """Get database session single instance."""
+    with Session(engine) as session:
+        yield session

--- a/src/api/core/warren/indicators/__init__.py
+++ b/src/api/core/warren/indicators/__init__.py
@@ -1,3 +1,4 @@
 """Warren indicators."""
 
 from .base import BaseIndicator  # noqa: F401
+from .mixins import IncrementalCacheMixin  # noqa: F401

--- a/src/api/core/warren/indicators/base.py
+++ b/src/api/core/warren/indicators/base.py
@@ -1,4 +1,6 @@
 """Abstract class defining the interface for an indicator."""
+import copy
+import inspect
 from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import cached_property
@@ -19,23 +21,60 @@ class BaseIndicator(ABC):
     for indicators.
     """
 
-    def __init__(self, span_range: DatetimeRange = None):
+    def __init__(self, span_range: DatetimeRange = None, **kwargs):
         """Instantiate the base indicator.
 
         Args:
             span_range (DatetimeRange): date/time span range on which
             the indicator needs to be computed
+
+            kwargs (dict): indicator-specific extra arguments that will
+            be stored as indicator attributes.
         """
-        self.span_range = span_range
+        super().__setattr__("span_range", span_range)
+        for attr, value in kwargs.items():
+            super().__setattr__(attr, value)
+
+    def __setattr__(self, name, value):
+        """Indicators are immutable, setattr is forbidden."""
+        raise AttributeError(f"Can't set attribute '{name}'")
+
+    def __delattr__(self, name):
+        """Indicators are immutable, delattr is forbidden."""
+        raise AttributeError(f"Can't delete attribute '{name}'")
+
+    def _replace(self, deep=False, **kwargs):
+        """Return an indicator copy with overridden kwargs.
+
+        Args:
+            deep (bool): if True perform a deep copy (defaults to shallow)
+            kwargs (dict): additional arguments
+
+        Disclaimer:
+            As by default we perform a shallow copy of indicator attributes,
+            you must be aware of consequencies when an indicator attribute is
+            passed as reference: the original object passed as a reference may
+            be modified in the original indicator instance AND its copy.
+        """
+        copy_ = copy.deepcopy if deep else copy.copy
+        self_args = copy_(self.__dict__)
+        other_args = {
+            param.name: self_args[param.name]
+            for param in inspect.signature(self.__init__).parameters.values()
+            if param.name in self_args
+        }
+        other_args.update(kwargs)
+
+        return self.__class__(**other_args)
 
     @property
     def since(self) -> datetime:
-        """Shorcut to the indicator date/time span minimal value."""
+        """Shortcut to the indicator date/time span minimal value."""
         return self.span_range.since
 
     @property
     def until(self) -> datetime:
-        """Shorcut to the indicator date/time span maximal value."""
+        """Shortcut to the indicator date/time span maximal value."""
         return self.span_range.until
 
     @cached_property
@@ -44,14 +83,10 @@ class BaseIndicator(ABC):
         return async_lrs_client
 
     @abstractmethod
-    def get_lrs_query(
-        self, since: datetime = None, until: datetime = None
-    ) -> LRSStatementsQuery:
+    def get_lrs_query(self) -> LRSStatementsQuery:
         """Get the LRS query for fetching statements."""
 
-    async def fetch_statements(
-        self, lrs_query: LRSStatementsQuery = None
-    ) -> List[XAPI_STATEMENT]:
+    async def fetch_statements(self) -> List[XAPI_STATEMENT]:
         """Execute the LRS query to obtain statements required for this indicator.
 
         If lrs_query is None, it defaults to self.get_lrs_query()
@@ -61,12 +96,12 @@ class BaseIndicator(ABC):
                 value
                 async for value in self.lrs_client.read(
                     target=self.lrs_client.statements_endpoint,
-                    query=lrs_query or self.get_lrs_query(),
+                    query=self.get_lrs_query(),
                 )
             ]
         except BackendException as exception:
             raise LrsClientException("Failed to fetch statements") from exception
 
     @abstractmethod
-    async def compute(self, since: datetime = None, until: datetime = None):
+    async def compute(self):
         """Execute the LRS query, and perform operations to get the indicator value."""

--- a/src/api/core/warren/indicators/mixins.py
+++ b/src/api/core/warren/indicators/mixins.py
@@ -10,7 +10,7 @@ import arrow
 from pydantic.main import BaseModel
 from sqlmodel import Session, select
 
-from warren.db import engine as db_engine
+from warren.db import get_session as get_db_session
 from warren.filters import DatetimeRange
 
 from .models import CacheEntry, CacheEntryCreate
@@ -43,13 +43,10 @@ logger = logging.getLogger(__name__)
 class CacheMixin:
     """A cache mixin that handles indicator persistence."""
 
-    db_engine = db_engine
-
     @cached_property
-    def db_session(self):
-        """Get a database session."""
-        with Session(self.db_engine) as session:
-            return session
+    def db_session(self) -> Session:
+        """Get the database session singleton."""
+        return next(get_db_session())
 
     @cached_property
     def cache_key(self) -> str:

--- a/src/api/core/warren/models.py
+++ b/src/api/core/warren/models.py
@@ -1,7 +1,8 @@
 """Warren's core models."""
+from datetime import datetime
 from functools import reduce
 from itertools import groupby
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import arrow
 from lti_toolbox.launch_params import LTIRole
@@ -10,7 +11,6 @@ from pydantic.main import BaseModel
 from ralph.backends.database.base import StatementParameters
 
 from warren.fields import Date
-from warren.filters import DatetimeRange
 
 XAPI_STATEMENT = Dict[str, Any]
 
@@ -57,6 +57,57 @@ class DailyCount(BaseModel):
         return DailyCount(date=self.date, count=self.count + other.count)
 
 
+class DailyUniqueCount(BaseModel):
+    """Base model to represent a unique user count for a date."""
+
+    date: Date
+    count: int = 0
+    users: Set[str] = set()
+
+    def __add__(self, other):
+        """Add counters for two DailyUniqueCount instances with the same date.
+
+        Args:
+            other (DailyUniqueCount): Another DailyUniqueCount instance with the
+            same date.
+
+        Returns:
+            DailyUniqueCount: A new DailyUniqueCount instance with the combined count
+            for the same date.
+
+        Raises:
+            ValueError: If 'other' has a different date than the current
+            instance.
+
+        Example:
+            # Creating two DailyUniqueCount instances with the same date
+            count1 = DailyUniqueCount(date="2023-09-19", count=10)
+            count2 = DailyUniqueCount(date="2023-09-19", count=5)
+
+            # Adding the counts for these instances
+            total_count = count1 + count2
+
+            # The 'total_count' instance now has a count of 15 for the same
+            #  date "2023-09-19".
+
+        Note:
+            When adding two `DailyUniqueCount` instances, it's required that they
+            have the same date. Attempting to add instances with different
+            dates will raise a `ValueError`.
+
+        """
+        if self.date != other.date:
+            raise ValueError(
+                "Cannot add two DailyUniqueCount instances with different dates"
+            )
+        users = self.users | other.users
+        return DailyUniqueCount(date=self.date, count=len(users), users=users)
+
+    def to_daily_count(self):
+        """Convert DailyUniqueCount to DailyCount."""
+        return DailyCount(date=self.date, count=self.count)
+
+
 class DailyCounts(BaseModel):
     """Base model to represent daily counts summary."""
 
@@ -64,7 +115,7 @@ class DailyCounts(BaseModel):
     counts: List[DailyCount] = []
 
     @classmethod
-    def from_range(cls, date_range: DatetimeRange):
+    def from_range(cls, since: datetime, until: datetime):
         """Initialize DailyCounts from a date range.
 
         Examples:
@@ -76,10 +127,7 @@ class DailyCounts(BaseModel):
             daily_counts = DailyCounts.from_range(date_range)
         """
         return cls(
-            counts=[
-                DailyCount(date=d)
-                for d in arrow.Arrow.range("day", date_range.since, date_range.until)
-            ]
+            counts=[DailyCount(date=d) for d in arrow.Arrow.range("day", since, until)]
         )
 
     def merge_counts(self, counts: List[DailyCount]):
@@ -114,6 +162,80 @@ class DailyCounts(BaseModel):
             for k, v in groupby(self.counts, lambda dc: dc.date)
         ]
         self.total = sum(dc.count for dc in self.counts)
+
+
+class DailyUniqueCounts(BaseModel):
+    """Base model to represent daily unique counts summary."""
+
+    total: int = 0
+    counts: List[DailyUniqueCount] = []
+
+    @classmethod
+    def from_range(cls, since: datetime, until: datetime):
+        """Initialize DailyUniqueCounts from a date range.
+
+        Examples:
+            # Initialize DailyUniqueCounts for a date range
+            date_range = DatetimeRange(
+                since=arrow.get("2023-01-01"),
+                until=arrow.get("2023-01-05")
+            )
+            daily_unique_counts = DailyUniqueCounts.from_range(date_range)
+        """
+        return cls(
+            counts=[
+                DailyUniqueCount(date=d) for d in arrow.Arrow.range("day", since, until)
+            ]
+        )
+
+    def merge_counts(self, counts: List[DailyUniqueCount]):
+        """Merge DailyUniqueCount objects by date and aggregate counts.
+
+        This method allows us to combine a list of DailyUniqueCount objects
+        into the existing 'counts' list and user sets, aggregating the counts
+        for each date and ensuring that 'counts' contains only unique
+        DailyUniqueCount objects with one count per day and the user is counted only
+        once in the date range.
+
+        Examples:
+            # Initialize DailyUniqueCounts for a date range
+            date_range = DatetimeRange(
+                since=arrow.get("2023-01-01"),
+                until=arrow.get("2023-01-05")
+            )
+            daily_unique_counts = DailyUniqueCounts.from_range(date_range)
+
+            # Merge new DailyUniqueCount
+            new_counts = [
+                DailyUniqueCount(date="2023-09-19", count=2, users={"bob", "jane"})
+            ]
+            daily_unique_counts.merge_counts(new_counts)
+
+        Note:
+            When merging `DailyUniqueCount` instances, the merged output will
+            be sorted by ascending date.
+
+        """
+        self.counts += counts
+        self.counts.sort(key=lambda x: x.date)
+        self.counts = [
+            reduce(lambda x, y: x + y, v)
+            for k, v in groupby(self.counts, lambda dc: dc.date)
+        ]
+        # Only consider the first occurence of a user along the date range
+        users = set()
+        self.total = 0
+        for count in self.counts:
+            count.users = count.users - users
+            count.count = len(count.users)
+            self.total += count.count
+            users |= count.users
+
+    def to_daily_counts(self):
+        """Convert DailyUniqueCounts to DailyCounts."""
+        counts = [c.to_daily_count() for c in self.counts]
+        total = sum(c.count for c in counts)
+        return DailyCounts(total=total, counts=counts)
 
 
 # FIXME: prefer using a valid generic pydantic model, this is too convoluted.

--- a/src/api/core/warren/tests/conftest.py
+++ b/src/api/core/warren/tests/conftest.py
@@ -9,6 +9,5 @@ from .fixtures.auth import auth_headers
 from .fixtures.db import (
     db_engine,
     db_session,
-    db_transaction,
     force_db_test_session,
 )

--- a/src/api/core/warren/tests/fixtures/db.py
+++ b/src/api/core/warren/tests/fixtures/db.py
@@ -48,7 +48,6 @@ def db_session(db_engine):
 
 
 @pytest.fixture(autouse=True, scope="function")
-def force_db_test_session(db_engine, db_session, monkeypatch):
+def force_db_test_session(db_session, monkeypatch):
     """Use test database along with a test session by default."""
-    monkeypatch.setattr(CacheMixin, "db_engine", db_engine)
     monkeypatch.setattr(CacheMixin, "db_session", db_session)

--- a/src/api/core/warren/tests/test_indicators_base.py
+++ b/src/api/core/warren/tests/test_indicators_base.py
@@ -39,39 +39,6 @@ async def test_base_indicator_fetch_statements_with_default_query(
 
 
 @pytest.mark.anyio
-async def test_base_indicator_fetch_statements_with_custom_query(
-    httpx_mock: HTTPXMock,
-):
-    """Test the `fetch_statements` method of the base indicator using a custom
-    LRS query.
-
-    """  # noqa: D205
-
-    class MyIndicator(BaseIndicator):
-        def get_lrs_query(self):
-            return LRSQuery(query={"verb": "played"})
-
-        async def compute(self):
-            return None
-
-    my_indicator = MyIndicator()
-    my_indicator.lrs_client.base_url = "http://fake-lrs.com"
-
-    # Mock the LRS call so that it returns the fixture statements
-    httpx_mock.add_response(
-        url="http://fake-lrs.com/xAPI/statements?verb=downloaded&limit=0",
-        method="GET",
-        json={"statements": [{"id": 1}, {"id": 2}, {"id": 3}]},
-        status_code=200,
-    )
-
-    statements = await my_indicator.fetch_statements(
-        lrs_query=LRSQuery(query={"verb": "downloaded", "limit": 0})
-    )
-    assert len(statements) == 3
-
-
-@pytest.mark.anyio
 async def test_base_indicator_fetch_statements_with_lrs_failure(
     httpx_mock: HTTPXMock,
 ):
@@ -99,3 +66,80 @@ async def test_base_indicator_fetch_statements_with_lrs_failure(
 
     with pytest.raises(LrsClientException):
         await my_indicator.fetch_statements()
+
+
+def test_base_indicator_replace():
+    """Test the base indicator _replace method."""
+
+    class MyIndicator(BaseIndicator):
+        def __init__(self, span_range=None, foo=None, bar=None):
+            super().__init__(span_range=span_range, foo=foo, bar=bar)
+
+        def get_lrs_query(self):
+            return None
+
+        async def compute(self):
+            return None
+
+    indicator = MyIndicator(foo="lol", bar=[1, 2, 3])
+    assert indicator.span_range is None
+    assert indicator.foo == "lol"
+    assert indicator.bar == [1, 2, 3]
+
+    # Shallow copy
+    copied = indicator._replace(foo="baz", bar=[4, 5, 6])
+    assert copied.span_range is None
+    assert copied.foo == "baz"
+    assert copied.bar == [4, 5, 6]
+
+    # Deep copy
+    copied = indicator._replace(deep=True, foo="baz", bar=[4, 5, 6])
+    assert copied.span_range is None
+    assert copied.foo == "baz"
+    assert copied.bar == [4, 5, 6]
+
+    # Proceed by reference to check differences between shallow and deep copies
+    bar = [1, 2, 3]
+    indicator = MyIndicator(foo="lol", bar=bar)
+
+    shallow = indicator._replace(deep=False, foo="baz")
+    deep = indicator._replace(deep=True, foo="baz")
+    assert shallow.bar == [1, 2, 3]
+    assert deep.bar == [1, 2, 3]
+
+    bar.append(4)
+    assert indicator.bar == shallow.bar == [1, 2, 3, 4]
+    assert deep.bar == [1, 2, 3]
+
+
+def test_base_indicator_child_immutability():
+    """Check indicators immutability."""
+
+    class MyIndicator(BaseIndicator):
+        def __init__(self, span_range=None, foo=None, bar=None):
+            super().__init__(span_range=span_range, foo=foo, bar=bar)
+
+        def get_lrs_query(self):
+            return None
+
+        async def compute(self):
+            return None
+
+    indicator = MyIndicator(foo="lol", bar=[1, 2, 3])
+
+    assert indicator.span_range is None
+    assert indicator.foo == "lol"
+    assert indicator.bar == [1, 2, 3]
+
+    with pytest.raises(AttributeError, match="Can't set attribute 'span_range'"):
+        indicator.span_range = [1, 2]
+    with pytest.raises(AttributeError, match="Can't set attribute 'foo'"):
+        indicator.foo = "spam"
+    with pytest.raises(AttributeError, match="Can't set attribute 'bar'"):
+        indicator.bar = 4
+    with pytest.raises(AttributeError, match="Can't delete attribute 'span_range'"):
+        del indicator.span_range
+    with pytest.raises(AttributeError, match="Can't delete attribute 'foo'"):
+        del indicator.foo
+    with pytest.raises(AttributeError, match="Can't delete attribute 'bar'"):
+        del indicator.bar

--- a/src/api/core/warren/tests/test_indicators_mixins.py
+++ b/src/api/core/warren/tests/test_indicators_mixins.py
@@ -1,6 +1,7 @@
 """Test indicators mixins."""
 import hashlib
 from datetime import datetime, timezone
+from functools import cached_property
 from itertools import chain
 from typing import Union
 from unittest.mock import AsyncMock
@@ -8,7 +9,9 @@ from unittest.mock import AsyncMock
 import pytest
 from arrow import Arrow
 from freezegun import freeze_time
+from pydantic import BaseModel
 from ralph.backends.http.async_lrs import LRSQuery
+from sqlalchemy import func
 from sqlalchemy.exc import MultipleResultsFound
 from sqlmodel import select
 
@@ -249,8 +252,113 @@ async def test_get_cache_when_unexpected_multiple_cache_exist(db_session):
         await indicator.get_cache()
 
 
+def test_compute_annotation():
+    """Test the _compute_annotation cached property."""
+
+    class MyIndicator(CacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        def get_lrs_query(self) -> LRSQuery:
+            return None
+
+        async def fetch_statements(self):
+            pass
+
+        async def compute(self):
+            pass
+
+    with pytest.raises(
+        TypeError,
+        match="compute method of an indicator should declare a return annotation",
+    ):
+        _ = MyIndicator()._compute_annotation
+
+    class NewIndicator(MyIndicator):
+        async def compute(self) -> list:
+            pass
+
+    assert NewIndicator()._compute_annotation == list
+
+
 @pytest.mark.anyio
-async def test_get_or_compute(db_session):
+@pytest.mark.parametrize(
+    "value",
+    [
+        '{"foo":"lol","bar":1}',
+        {"foo": "lol", "bar": 1},
+    ],
+)
+async def test_to_pydantic(value):
+    """Test _to_pydantic method."""
+
+    class MyType(BaseModel):
+        foo: str
+        bar: int
+
+    class MyIndicator(CacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        def get_lrs_query(self) -> LRSQuery:
+            pass
+
+        async def compute(self) -> MyType:
+            pass
+
+    indicator = MyIndicator()
+    assert indicator._to_pydantic(indicator._compute_annotation, value) == MyType(
+        foo="lol", bar=1
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "value",
+    [
+        '{"foo":"lol","bar":1}',
+        {"foo": "lol", "bar": 1},
+    ],
+)
+async def test_raw_or_pydantic(value):
+    """Test _raw_or_pydantic method."""
+
+    class MyType(BaseModel):
+        foo: str
+        bar: int
+
+    class MyIndicator(CacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        def get_lrs_query(self) -> LRSQuery:
+            pass
+
+        async def compute(self) -> MyType:
+            pass
+
+    indicator = MyIndicator()
+    assert indicator._raw_or_pydantic(value) == MyType(foo="lol", bar=1)
+
+    class MyIndicator(CacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        def get_lrs_query(self) -> LRSQuery:
+            pass
+
+        # For python >= 3.11, "Any" is recognized as a class:
+        #
+        # async def compute(self) -> Any:
+        #
+        # ... but not with prior versions, hence we fake return annotation with
+        # anything that is not a Pydantic model so that we don't try to cast
+        # computed result:
+        async def compute(self) -> str:
+            pass
+
+    indicator = MyIndicator()
+    assert indicator._raw_or_pydantic(value) == value
+
+
+@pytest.mark.anyio
+async def test_get_or_compute(db_session, monkeypatch):
     """Test getting cached results from the database or compute them."""
 
     class MyIndicator(CacheMixin, BaseIndicator):
@@ -262,7 +370,7 @@ async def test_get_or_compute(db_session):
         async def fetch_statements(self):
             pass
 
-        async def compute(self):
+        async def compute(self) -> dict:
             return {"foo": [1, 2, 3]}
 
     indicator = MyIndicator()
@@ -282,8 +390,22 @@ async def test_get_or_compute(db_session):
     assert len(cached) == 1
     assert cached[0].value == {"foo": [1, 2, 3]}
 
-    # Mock the compute method so that we can spy on it and change the result
-    indicator.compute = AsyncMock(return_value={"foo": [4, 5, 6]})
+    class MyIndicator(CacheMixin, BaseIndicator):
+        """Dummy mocked indicator."""
+
+        def get_lrs_query(self) -> LRSQuery:
+            return LRSQuery(query={"verb": "played"})
+
+        async def fetch_statements(self):
+            pass
+
+        @cached_property
+        def _compute_annotation(self):
+            return dict
+
+        compute = AsyncMock(return_value={"foo": [4, 5, 6]})
+
+    indicator = MyIndicator()
 
     # Call compute once again and ensure we don't recalculate the results
     result = await indicator.get_or_compute()
@@ -363,6 +485,144 @@ async def test_incremental_get_cache(db_session):
     caches = await indicator.get_cache()
     assert len(caches) == 10
     for cache, day in zip(caches, chain(range(10, 16), range(18, 22))):
+        assert cache.value.get("day") == day
+
+
+@pytest.mark.anyio
+async def test_incremental_get_cache_when_multiple_cache_exists(db_session):
+    """Test getting cache(s) for the incremental mixin with existing cache."""
+
+    class MyDailyIndicator(IncrementalCacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        frame = "day"
+
+        def get_lrs_query(
+            self, since: datetime = None, until: datetime = None
+        ) -> LRSQuery:
+            return LRSQuery(query={"verb": "played", "since": since, "until": until})
+
+        async def fetch_statements(self):
+            pass
+
+        async def compute(self, since: datetime = None, until: datetime = None):
+            return {
+                "day": since.day,
+                "lrs_query": self.get_lrs_query(since=since, until=until).json(),
+            }
+
+        @staticmethod
+        def merge(a: dict, b: dict):
+            return (a, b)
+
+    indicator = MyDailyIndicator(
+        span_range=DatetimeRange(
+            since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
+        )
+    )
+    # Check that nothing already exists in the database
+    caches = db_session.exec(
+        select(CacheEntry).where(CacheEntry.key == indicator.cache_key)
+    ).all()
+    assert len(caches) == 0
+
+    # Create a cache entry and check we can get it back
+    for since, until in chain(
+        Arrow.span_range("day", Arrow(2023, 1, 10), Arrow(2023, 1, 15)),
+        Arrow.span_range("day", Arrow(2023, 1, 18), Arrow(2023, 1, 21)),
+    ):
+        db_session.add(
+            CacheEntry(
+                key=indicator.cache_key,
+                value={
+                    "day": since.day,
+                    "lrs_query": indicator.get_lrs_query(
+                        since=since.datetime, until=until.datetime
+                    ).json(),
+                },
+                since=since.datetime,
+                until=until.datetime,
+            )
+        )
+    db_session.add(
+        CacheEntry(
+            key="foo", value=[1], since=datetime(2023, 1, 5), until=datetime(2023, 1, 6)
+        )
+    )
+    db_session.add(
+        CacheEntry(
+            key="bar", value=[2], since=datetime(2013, 1, 3), until=datetime(2023, 1, 4)
+        )
+    )
+    db_session.commit()
+    caches = await indicator.get_cache()
+    assert len(caches) == 10
+    for cache, day in zip(caches, chain(range(10, 16), range(18, 22))):
+        assert cache.value.get("day") == day
+
+
+@pytest.mark.anyio
+async def test_incremental_get_cache_limits(db_session):
+    """Test getting cache(s) for the incremental mixin when querying date span range."""
+
+    class MyDailyIndicator(IncrementalCacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        frame = "day"
+
+        def get_lrs_query(
+            self, since: datetime = None, until: datetime = None
+        ) -> LRSQuery:
+            return LRSQuery(query={"verb": "played", "since": since, "until": until})
+
+        async def fetch_statements(self):
+            pass
+
+        async def compute(self, since: datetime = None, until: datetime = None):
+            return {
+                "day": since.day,
+                "lrs_query": self.get_lrs_query(since=since, until=until).json(),
+            }
+
+        @staticmethod
+        def merge(a: dict, b: dict):
+            return (a, b)
+
+    indicator = MyDailyIndicator(
+        span_range=DatetimeRange(
+            since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
+        )
+    )
+    # Check that nothing already exists in the database
+    caches = db_session.exec(
+        select(CacheEntry).where(CacheEntry.key == indicator.cache_key)
+    ).all()
+    assert len(caches) == 0
+
+    # Create a cache entry and check we can get it back
+    for since, until in Arrow.span_range("day", Arrow(2023, 1, 1), Arrow(2023, 1, 31)):
+        db_session.add(
+            CacheEntry(
+                key=indicator.cache_key,
+                value={
+                    "day": since.day,
+                    "lrs_query": indicator.get_lrs_query(
+                        since=since.datetime, until=until.datetime
+                    ).json(),
+                },
+                since=since.datetime,
+                until=until.datetime,
+            )
+        )
+    db_session.commit()
+    caches = db_session.exec(
+        select(CacheEntry).where(CacheEntry.key == indicator.cache_key)
+    ).all()
+    assert len(caches) == 31
+
+    caches = await indicator.get_cache()
+    assert len(caches) == 31
+    for cache, day in zip(caches, range(1, 31)):
         assert cache.value.get("day") == day
 
 
@@ -517,6 +777,104 @@ async def test_incremental_merge():
 
 
 @pytest.mark.anyio
+async def test_incremental_compute_annotation():
+    """Test _compute_annotation property of the incremental mixin."""
+
+    class MyDailyIndicator(IncrementalCacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        frame = "day"
+
+        def get_lrs_query(self) -> LRSQuery:
+            pass
+
+        async def compute(self) -> dict:
+            return {}
+
+        @staticmethod
+        def merge(a, b) -> list:
+            return []
+
+    indicator = MyDailyIndicator(
+        span_range=DatetimeRange(
+            since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
+        )
+    )
+
+    assert indicator._compute_annotation == dict
+
+    class MyType(BaseModel):
+        foo: str
+        bar: dict
+
+    class MyDailyIndicator(IncrementalCacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        frame = "day"
+
+        def get_lrs_query(self) -> LRSQuery:
+            pass
+
+        async def compute(self) -> MyType:
+            return {}
+
+        @staticmethod
+        def merge(a, b) -> list:
+            return []
+
+    indicator = MyDailyIndicator(
+        span_range=DatetimeRange(
+            since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
+        )
+    )
+    assert indicator._compute_annotation == MyType
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "values",
+    [
+        ['{"foo":"lol","bar":1}', '{"foo":"spam","bar":2}'],
+        [{"foo": "lol", "bar": 1}, {"foo": "spam", "bar": 2}],
+        ['{"foo":"lol","bar":1}', {"foo": "spam", "bar": 2}],
+    ],
+)
+async def test_incremental_to_pydantic(values):
+    """Test _to_pydantic method of the incremental mixin."""
+
+    class MyType(BaseModel):
+        foo: str
+        bar: int
+
+    class MyDailyIndicator(IncrementalCacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        frame = "day"
+
+        def get_lrs_query(self) -> LRSQuery:
+            pass
+
+        async def compute(self) -> MyType:
+            pass
+
+        @staticmethod
+        def merge(a, b) -> list:
+            pass
+
+    indicator = MyDailyIndicator(
+        span_range=DatetimeRange(
+            since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
+        )
+    )
+    assert [
+        indicator._to_pydantic(indicator._compute_annotation, value) for value in values
+    ] == [
+        MyType(foo="lol", bar=1),
+        MyType(foo="spam", bar=2),
+    ]
+
+
+@pytest.mark.anyio
 async def test_incremental_get_or_compute(db_session):
     """Test get or compute method of the incremental mixin."""
 
@@ -525,18 +883,195 @@ async def test_incremental_get_or_compute(db_session):
 
         frame = "day"
 
-        def get_lrs_query(
-            self, since: datetime = None, until: datetime = None
-        ) -> LRSQuery:
-            return LRSQuery(query={"verb": "played", "since": since, "until": until})
+        def get_lrs_query(self) -> LRSQuery:
+            return LRSQuery(
+                query={"verb": "played", "since": self.since, "until": self.until}
+            )
 
         async def fetch_statements(self):
             pass
 
-        async def compute(self, since: datetime = None, until: datetime = None):
+        async def compute(self) -> dict:
             return {
-                "day": since.day,
-                "lrs_query": self.get_lrs_query(since=since, until=until).json(),
+                "day": self.since.day,
+                "lrs_query": self.get_lrs_query().json(),
+            }
+
+        @staticmethod
+        def merge(a: Union[dict, list], b: dict) -> list:
+            if isinstance(a, dict):
+                a = [a]
+            return a + [b]
+
+    indicator = MyDailyIndicator(
+        span_range=DatetimeRange(
+            since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
+        )
+    )
+    # Check that nothing already exists in the database
+    caches = db_session.exec(
+        select(CacheEntry).where(CacheEntry.key == indicator.cache_key)
+    ).all()
+    assert len(caches) == 0
+    caches = await indicator.get_cache()
+    assert len(caches) == 0
+
+    # Create cache entries and check we can get them back
+    for since, until in chain(
+        Arrow.span_range("day", Arrow(2023, 1, 10), Arrow(2023, 1, 15)),
+        Arrow.span_range("day", Arrow(2023, 1, 18), Arrow(2023, 1, 21)),
+    ):
+        db_session.add(
+            CacheEntry(
+                key=indicator.cache_key,
+                value={
+                    "day": since.day,
+                    "lrs_query": MyDailyIndicator(
+                        span_range=DatetimeRange(
+                            since=since.datetime, until=until.datetime
+                        )
+                    )
+                    .get_lrs_query()
+                    .json(),
+                },
+                since=since.datetime,
+                until=until.datetime,
+            )
+        )
+    db_session.commit()
+    caches = db_session.exec(
+        select(CacheEntry).where(CacheEntry.key == indicator.cache_key)
+    ).all()
+    assert len(caches) == 10
+
+    results = await indicator.get_or_compute()
+
+    # We expect 31 results...
+    assert len(results) == 31
+    assert [result.get("day") for result in results] == list(range(1, 32))
+
+    # ... stored in the database
+    caches = db_session.exec(
+        select(CacheEntry).where(CacheEntry.key == indicator.cache_key)
+    ).all()
+    assert len(caches) == 31
+
+
+@pytest.mark.anyio
+async def test_incremental_get_or_compute_update(db_session):
+    """Test incremental cache update."""
+    delta = 1
+
+    class MyDailyIndicator(IncrementalCacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        frame = "day"
+
+        def get_lrs_query(self) -> LRSQuery:
+            return LRSQuery(
+                query={"verb": "played", "since": self.since, "until": self.until}
+            )
+
+        async def fetch_statements(self):
+            pass
+
+        async def compute(self) -> dict:
+            return {
+                "day": self.since.day,
+                "views": self.since.day + delta,
+            }
+
+        @staticmethod
+        def merge(a: Union[dict, list], b: dict) -> list:
+            if isinstance(a, dict):
+                a = [a]
+            return a + [b]
+
+    indicator = MyDailyIndicator(
+        span_range=DatetimeRange(
+            since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
+        )
+    )
+    # Check that nothing already exists in the database
+    caches = db_session.exec(
+        select(CacheEntry).where(CacheEntry.key == indicator.cache_key)
+    ).all()
+    assert len(caches) == 0
+    caches = await indicator.get_cache()
+    assert len(caches) == 0
+
+    # Create cache entries and check we can get them back
+    for since, until in chain(
+        Arrow.span_range("day", Arrow(2023, 1, 10), Arrow(2023, 1, 15)),
+        Arrow.span_range("day", Arrow(2023, 1, 18), Arrow(2023, 1, 21)),
+    ):
+        db_session.add(
+            CacheEntry(
+                key=indicator.cache_key,
+                value={
+                    "day": since.day,
+                    "views": since.day + 1,
+                },
+                since=since.datetime,
+                until=until.datetime,
+            )
+        )
+    db_session.commit()
+    assert (
+        db_session.exec(
+            select([func.count()])
+            .select_from(CacheEntry)
+            .where(CacheEntry.key == indicator.cache_key)
+        ).one()
+        == 10
+    )
+
+    results = await indicator.get_or_compute()
+    assert len(results) == 31
+    assert [result.get("day") for result in results] == list(range(1, 32))
+    assert [result.get("views") for result in results] == list(range(2, 33))
+
+    delta = 2
+    results = await indicator.get_or_compute(update=True)
+    assert len(results) == 31
+    assert [result.get("day") for result in results] == list(range(1, 32))
+    assert [result.get("views") for result in results] == list(range(3, 34))
+
+    cached = db_session.exec(
+        select(CacheEntry)
+        .where(CacheEntry.key == indicator.cache_key)
+        .order_by(CacheEntry.since)
+    ).all()
+    assert len(cached) == 31
+    assert cached[0].value == {"day": 1, "views": 3}
+
+
+@pytest.mark.anyio
+async def test_incremental_get_or_compute_update_and_create(db_session):
+    """Test incremental cache update and creation at once.
+
+    In this case we update existing entries and save new ones instead of
+    updating all entries (see test_incremental_get_or_compute_update test).
+    """
+    delta = 2
+
+    class MyDailyIndicator(IncrementalCacheMixin, BaseIndicator):
+        """Dummy indicator."""
+
+        frame = "day"
+
+        def get_lrs_query(self) -> LRSQuery:
+            return LRSQuery(
+                query={"verb": "played", "since": self.since, "until": self.until}
+            )
+
+        async def fetch_statements(self):
+            pass
+
+        async def compute(self) -> dict:
+            return {
+                "day": self.since.day,
+                "views": self.since.day + delta,
             }
 
         @staticmethod
@@ -576,15 +1111,14 @@ async def test_incremental_get_or_compute(db_session):
                 key=indicator.cache_key,
                 value={
                     "day": since.day,
-                    "lrs_query": indicator.get_lrs_query(
-                        since=since.datetime, until=until.datetime
-                    ).json(),
+                    "views": since.day + 1,
                 },
                 since=since.datetime,
                 until=until.datetime,
             )
         )
     db_session.commit()
-    results = await indicator.get_or_compute()
+    results = await indicator.get_or_compute(update=True)
     assert len(results) == 31
     assert [result.get("day") for result in results] == list(range(1, 32))
+    assert [result.get("views") for result in results] == list(range(3, 34))

--- a/src/api/core/warren/tests/test_models.py
+++ b/src/api/core/warren/tests/test_models.py
@@ -5,7 +5,41 @@ from random import randint
 import pytest
 
 from warren.filters import DatetimeRange
-from warren.models import DailyCount, DailyCounts
+from warren.models import DailyCount, DailyCounts, DailyUniqueCount, DailyUniqueCounts
+
+
+def test_daily_count_add():
+    """Test the `__add__` method from DailyCount model."""
+    # Define four DailyCount, three sharing the same date
+    count1 = DailyCount(date="2023-01-01", count=10)
+    count2 = DailyCount(date="2023-01-02", count=1)
+    count3 = DailyCount(date="2023-01-01", count=3)
+    count4 = DailyCount(date="2023-01-01", count=6)
+
+    # Sum DailyCount instances with the same date
+    count5 = count1 + count3
+    count6 = count1 + count3 + count4
+
+    # New DailyCount should be the sum of the initial ones
+    assert count5.count == count1.count + count3.count
+    assert count6.count == count1.count + count3.count + count4.count
+
+    # Ensure that the initial DailyCount instances remain unchanged
+    assert count1.count == 10
+    assert count3.count == 3
+    assert count4.count == 6
+
+    # Verify that attempting to add DailyCount instances with
+    # different dates raises an exception
+    msg = "Cannot add two DailyCount instances with different dates"
+    with pytest.raises(ValueError, match=msg):
+        count1 + count2
+
+    # Verify that attempting to add a DailyCount instance and a
+    # non-DailyCount value raises an exception
+    msg = "'int' object has no attribute 'date'"
+    with pytest.raises(AttributeError, match=msg):
+        count1 + 10
 
 
 def test_daily_counts_from_range():
@@ -13,7 +47,7 @@ def test_daily_counts_from_range():
     date_range = DatetimeRange.parse_obj({"since": "2022-12-31", "until": "2023-01-30"})
 
     # Create DailyCounts from the date range
-    daily_counts = DailyCounts.from_range(date_range)
+    daily_counts = DailyCounts.from_range(date_range.since, date_range.until)
 
     # Ensure there is one DailyCount per day, all initialized to zero
     assert len(daily_counts.counts) == 31
@@ -75,30 +109,27 @@ def test_daily_counts_merge_counts():
     ]
 
 
-def test_daily_count_add():
-    """Test the `__add__` method from DailyCount model."""
-    # Define four DailyCount, three sharing the same date
-    count1 = DailyCount(date="2023-01-01", count=10)
-    count2 = DailyCount(date="2023-01-02", count=1)
-    count3 = DailyCount(date="2023-01-01", count=3)
-    count4 = DailyCount(date="2023-01-01", count=6)
+def test_daily_unique_count_add():
+    """Test the `__add__` method from DailyUniqueCount model."""
+    count1 = DailyUniqueCount(
+        date="2023-01-01", count=3, users={"leia", "luke", "vader"}
+    )
+    count2 = DailyUniqueCount(date="2023-01-02", count=1, users={"luke"})
+    count3 = DailyUniqueCount(date="2023-01-01", count=2, users={"luke", "han"})
+    count4 = DailyUniqueCount(date="2023-01-01", count=0, users=set())
 
-    # Sum DailyCount instances with the same date
+    # Sum instances with the same date
     count5 = count1 + count3
     count6 = count1 + count3 + count4
 
-    # New DailyCount should be the sum of the initial ones
-    assert count5.count == count1.count + count3.count
-    assert count6.count == count1.count + count3.count + count4.count
-
-    # Ensure that the initial DailyCount instances remain unchanged
-    assert count1.count == 10
-    assert count3.count == 3
-    assert count4.count == 6
+    assert count5.count == 4
+    assert count5.users == {"leia", "luke", "vader", "han"}
+    assert count6.count == 4
+    assert count6.users == {"leia", "luke", "vader", "han"}
 
     # Verify that attempting to add DailyCount instances with
     # different dates raises an exception
-    msg = "Cannot add two DailyCount instances with different dates"
+    msg = "Cannot add two DailyUniqueCount instances with different dates"
     with pytest.raises(ValueError, match=msg):
         count1 + count2
 
@@ -107,3 +138,105 @@ def test_daily_count_add():
     msg = "'int' object has no attribute 'date'"
     with pytest.raises(AttributeError, match=msg):
         count1 + 10
+
+
+def test_daily_unique_count_to_daily_count():
+    """Test the `to_daily_count` method from DailyUniqueCount model."""
+    assert DailyUniqueCount(
+        date="2023-01-01", count=3, users={"leia", "luke", "vader"}
+    ).to_daily_count() == DailyCount(date="2023-01-01", count=3)
+
+
+def test_daily_unique_counts_from_range():
+    """Test the `from_range` class method from DailyUniqueCounts model."""
+    date_range = DatetimeRange.parse_obj({"since": "2022-12-31", "until": "2023-01-30"})
+
+    # Create DailyCounts from the date range
+    daily_counts = DailyUniqueCounts.from_range(date_range.since, date_range.until)
+
+    # Ensure there is one DailyCount per day, all initialized to zero
+    assert len(daily_counts.counts) == 31
+    assert daily_counts.total == 0
+
+    # DailyCounts should be sorted by date and have a count of zero
+    first_count = daily_counts.counts[0]
+    assert first_count.date == datetime.date(2022, 12, 31)
+    assert first_count.count == 0
+    assert first_count.users == set()
+
+    for idx, daily_count in enumerate(daily_counts.counts[1:]):
+        assert daily_count.date == datetime.date(2023, 1, idx + 1)
+        assert daily_count.count == 0
+        assert daily_count.users == set()
+
+
+def test_daily_unique_counts_merge_counts():
+    """Test the `merge_counts` method from DailyUniqueCounts model."""
+    count1 = DailyUniqueCount(
+        date="2023-01-01", count=3, users={"leia", "luke", "vader"}
+    )
+    count2 = DailyUniqueCount(date="2023-01-02", count=1, users={"luke"})
+    count3 = DailyUniqueCount(
+        date="2023-01-03", count=4, users={"luke", "han", "vader", "yoda"}
+    )
+
+    # Create a DailyCounts object and merge counts
+    counts = DailyUniqueCounts(
+        counts=[count1],
+        total=3,
+    )
+    counts.merge_counts([count2])
+
+    # Verify that counts on 2023-01-01 have been summed
+    assert counts.total == 3
+    assert counts.counts == [
+        DailyUniqueCount(date=count1.date, count=count1.count, users=count1.users),
+        DailyUniqueCount(date=count2.date, count=0, users=set()),
+    ]
+
+    # Add a new count with a new date
+    counts.merge_counts([count3])
+
+    # Ensure counts are sorted, and 2023-01-03 has been added at the end
+    assert counts.total == 5
+    assert counts.counts == [
+        DailyUniqueCount(date=count1.date, count=count1.count, users=count1.users),
+        DailyUniqueCount(date=count2.date, count=0, users=set()),
+        DailyUniqueCount(date=count3.date, count=2, users={"han", "yoda"}),
+    ]
+
+    # Merge several new counts with a new date
+    count4 = DailyUniqueCount(date="2022-12-31", count=1, users={"han"})
+    counts.merge_counts([count4])
+
+    # Ensure counts are sorted, and 2022-12-31 has been added at the start
+    assert counts.total == 5
+    assert counts.counts == [
+        count4,
+        DailyUniqueCount(date=count1.date, count=count1.count, users=count1.users),
+        DailyUniqueCount(date=count2.date, count=0, users=set()),
+        DailyUniqueCount(date=count3.date, count=1, users={"yoda"}),
+    ]
+
+
+def test_daily_unique_counts_to_daily_count():
+    """Test the `to_daily_count` method from DailyUniqueCounts model."""
+    assert DailyUniqueCounts(
+        total=8,
+        counts=[
+            DailyUniqueCount(
+                date="2023-01-01", count=3, users={"leia", "luke", "vader"}
+            ),
+            DailyUniqueCount(date="2023-01-02", count=1, users={"luke"}),
+            DailyUniqueCount(
+                date="2023-01-03", count=4, users={"luke", "han", "vader", "yoda"}
+            ),
+        ],
+    ).to_daily_counts() == DailyCounts(
+        total=8,
+        counts=[
+            DailyCount(date="2023-01-01", count=3),
+            DailyCount(date="2023-01-02", count=1),
+            DailyCount(date="2023-01-03", count=4),
+        ],
+    )

--- a/src/api/core/warren/tests/test_xapi.py
+++ b/src/api/core/warren/tests/test_xapi.py
@@ -126,6 +126,15 @@ def test_statements_transformer_add_actor_uid():
     assert len(ids_john.unique()) == 1
 
 
+def test_statements_transformer_preprocess_empty_statements():
+    """Test the preprocess_statements method of the PreprocessMixin.
+
+    Statements sent as arguments are None or an empty list.
+    """
+    assert StatementsTransformer.preprocess([]) is None
+    assert StatementsTransformer.preprocess(None) is None
+
+
 def test_statements_transformer_preprocess_statements_workflow():
     """Test the preprocess_statements method of the PreprocessMixin."""
     raw_statements = [

--- a/src/api/core/warren/xapi.py
+++ b/src/api/core/warren/xapi.py
@@ -1,12 +1,15 @@
 """xAPI data transformers."""
 import hashlib
-from typing import List
+import logging
+from typing import List, Optional
 
 import pandas as pd
 
 from warren.conf import settings
 from warren.models import XAPI_STATEMENT
 from warren.utils import pipe
+
+logger = logging.getLogger(__name__)
 
 
 class StatementsTransformer:
@@ -60,8 +63,14 @@ class StatementsTransformer:
         return statements
 
     @staticmethod
-    def preprocess(statements: List[XAPI_STATEMENT]) -> pd.DataFrame:
+    def preprocess(
+        statements: Optional[List[XAPI_STATEMENT]] = None,
+    ) -> Optional[pd.DataFrame]:
         """Normalize raw statements, and add utility columns."""
+        if statements is None or not len(statements):
+            logger.info("There are no statements to process")
+            return
+
         return pipe(
             StatementsTransformer.normalize,
             StatementsTransformer.add_actor_uid_column,

--- a/src/api/plugins/video/tests/conftest.py
+++ b/src/api/plugins/video/tests/conftest.py
@@ -1,9 +1,17 @@
 """Video plugin test fixtures."""
 
+# pylint: disable=unused-import
+# ruff: noqa: F401
+
 import pytest
-from warren.tests.fixtures.app import http_client  # noqa: F401
-from warren.tests.fixtures.asynchronous import anyio_backend  # noqa: F401
-from warren.tests.fixtures.auth import auth_headers  # noqa: F401
+from warren.tests.fixtures.app import http_client
+from warren.tests.fixtures.asynchronous import anyio_backend
+from warren.tests.fixtures.auth import auth_headers
+from warren.tests.fixtures.db import (
+    db_engine,
+    db_session,
+    force_db_test_session,
+)
 
 
 @pytest.fixture

--- a/src/api/plugins/video/tests/test_indicators.py
+++ b/src/api/plugins/video/tests/test_indicators.py
@@ -1,32 +1,41 @@
-"""Tests for the video indicators."""
+"""Tests for video indicators."""
+import json
+import re
+import urllib
 
+import httpx
 import pandas as pd
 import pytest
 from dateutil.tz import tzoffset
+from pytest_httpx import HTTPXMock
+from ralph.models.xapi.concepts.constants.video import RESULT_EXTENSION_TIME
+from warren.backends import lrs_client
 from warren.factories.base import BaseXapiStatementFactory
 from warren.filters import DatetimeRange
+from warren.models import DailyUniqueCount
 from warren.xapi import StatementsTransformer
-from warren_video.indicators import BaseDailyEvent
+from warren_video.factories import VideoPlayedFactory
+from warren_video.indicators import BaseDailyEvent, DailyEvent, DailyUniqueViews
 
 
 def test_base_daily_event_subclass_verb_id():
     """Test '__init_subclass__' for the BaseDailyEvent class."""
 
-    class MyIndicator(BaseDailyEvent):
+    class MyIndicator(DailyEvent):
         verb_id = "test"
 
     # the __init_subclass__ is called when the class itself is constructed.
     # It should raise an error because the 'verb_id' class attribute is missing.
     with pytest.raises(TypeError) as exception:
 
-        class MyIndicatorMissingAttribute(BaseDailyEvent):
+        class MyIndicatorMissingAttribute(DailyEvent):
             wrong_attribute = "test"
 
     assert str(exception.value) == "Indicators must declare a 'verb_id' class attribute"
 
 
-def test_base_daily_event_date_range_timezone():
-    """Test 'to_date_range_timezone' for the BaseDailyEvent class."""
+def test_base_daily_event_span_range_timezone():
+    """Test 'to_span_range_timezone' for the BaseDailyEvent class."""
     # Create source statements
     raw_statements = [
         BaseXapiStatementFactory.build(
@@ -40,12 +49,11 @@ def test_base_daily_event_date_range_timezone():
 
     # Create an indicator with a DateTimeRange in UTC
     indicator_utc = BaseDailyEvent(
-        date_range=DatetimeRange(since="2023-01-01", until="2023-01-03"),
+        span_range=DatetimeRange(since="2023-01-01", until="2023-01-03"),
         video_id="Test",
-        unique=True,
     )
     # Convert statements' timestamp
-    statements = indicator_utc.to_date_range_timezone(source_statements)
+    statements = indicator_utc.to_span_range_timezone(source_statements)
 
     expected_statements = pd.to_datetime(
         pd.Series(
@@ -62,14 +70,13 @@ def test_base_daily_event_date_range_timezone():
 
     # Create an indicator with a DateTimeRange in UTC+02:00
     indicator_with_timezone = BaseDailyEvent(
-        date_range=DatetimeRange(
+        span_range=DatetimeRange(
             since="2023-01-01T00:00:00+02:00", until="2023-01-03T00:00:00+02:00"
         ),
         video_id="Test",
-        unique=True,
     )
     # Convert statements' timestamp
-    statements = indicator_with_timezone.to_date_range_timezone(source_statements)
+    statements = indicator_with_timezone.to_span_range_timezone(source_statements)
 
     # Statements' timestamp should be in UTC+02:00
     assert statements["timestamp"].equals(
@@ -94,3 +101,93 @@ def test_base_daily_event_add_date_column():
         pd.to_datetime(pd.Series(["2023-01-01", "2023-01-03"], name="date")).dt.date
     )
     assert "timestamp" not in statements.columns
+
+
+@pytest.mark.anyio
+async def test_daily_unique_views(httpx_mock: HTTPXMock, db_session):
+    """Test the DailyUniqueViews indicator."""
+    video_id = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
+
+    local_template = VideoPlayedFactory.template
+    local_template["object"]["id"] = video_id
+    local_template["actor"] = {
+        "mbox": "mailto:luke@sw.com",
+        "objectType": "Agent",
+        "name": "luke",
+    }
+
+    class LocalVideoPlayedFactory(VideoPlayedFactory):
+        template: dict = local_template
+
+    def lrs_response(request: httpx.Request):
+        """Dynamic mock for the LRS response."""
+        statements = []
+        params = urllib.parse.parse_qs(request.url.query)
+        if (
+            params.get(b"since")[0] == b"2020-01-01T00:00:00+00:00"
+            and params.get(b"until")[0] == b"2020-01-01T23:59:59.999999+00:00"
+        ):
+            statements = [
+                json.loads(
+                    LocalVideoPlayedFactory.build(
+                        [
+                            {
+                                "result": {
+                                    "extensions": {
+                                        RESULT_EXTENSION_TIME: view_data["time"]
+                                    }
+                                }
+                            },
+                            {"timestamp": view_data["timestamp"]},
+                        ]
+                    ).json(),
+                )
+                for view_data in [
+                    {"timestamp": "2020-01-01T00:00:00.000+00:00", "time": 100},
+                    {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 200},
+                ]
+            ]
+        elif (
+            params.get(b"since")[0] == b"2020-01-02T00:00:00+00:00"
+            and params.get(b"until")[0] == b"2020-01-02T23:59:59.999999+00:00"
+        ):
+            statements = [
+                json.loads(
+                    LocalVideoPlayedFactory.build(
+                        [
+                            {"result": {"extensions": {RESULT_EXTENSION_TIME: 300}}},
+                            {"timestamp": "2020-01-02T00:00:00.000+00:00"},
+                        ]
+                    ).json(),
+                )
+            ]
+
+        return httpx.Response(
+            status_code=200,
+            json={"statements": statements},
+        )
+
+    # Mock the LRS call so that it returns the fixture statements
+    lrs_client.base_url = "http://fake-lrs.com"
+    httpx_mock.add_callback(
+        callback=lrs_response,
+        url=re.compile(r"^http://fake-lrs\.com/xAPI/statements\?.*$"),
+        method="GET",
+    )
+
+    span_range = DatetimeRange(since="2020-01-01", until="2020-01-03")
+    indicator = DailyUniqueViews(video_id=video_id, span_range=span_range)
+    daily_counts = await indicator.get_or_compute()
+
+    # Generate an example statement to get default actor uid
+    example_statements: pd.DataFrame = StatementsTransformer.preprocess(
+        [json.loads(LocalVideoPlayedFactory.build().json())]
+    )
+    assert daily_counts.total == 1
+    assert daily_counts.counts == [
+        DailyUniqueCount(
+            date="2020-01-01", count=1, users={example_statements["actor.uid"][0]}
+        ),
+        DailyUniqueCount(date="2020-01-02", count=0, users=set()),
+        DailyUniqueCount(date="2020-01-03", count=0, users=set()),
+    ]

--- a/src/api/plugins/video/warren_video/api.py
+++ b/src/api/plugins/video/warren_video/api.py
@@ -6,9 +6,16 @@ from typing_extensions import Annotated  # python <3.9 compat
 from warren.exceptions import LrsClientException
 from warren.fields import IRI
 from warren.filters import BaseQueryFilters, DatetimeRange
-from warren.models import DailyCounts, LTIToken
+from warren.models import DailyCounts, DailyUniqueCounts, LTIToken
 from warren.utils import get_lti_token
-from warren_video.indicators import DailyCompletedViews, DailyDownloads, DailyViews
+from warren_video.indicators import (
+    DailyCompletedViews,
+    DailyDownloads,
+    DailyUniqueCompletedViews,
+    DailyUniqueDownloads,
+    DailyUniqueViews,
+    DailyViews,
+)
 
 router = APIRouter(
     prefix="/video",
@@ -26,25 +33,31 @@ async def views(
     unique: bool = False,
 ) -> DailyCounts:
     """Number of views for `video_id` in the `since` -> `until` date range."""
-    indicator_kwargs = {
-        "video_id": video_id,
-        "date_range": DatetimeRange.parse_obj(filters),
-        "unique": unique,
+    # Switch/case pattern matching with the (complete, unique) boolean tuple
+    klass_mapping = {
+        (True, True): DailyUniqueCompletedViews,
+        (True, False): DailyCompletedViews,
+        (False, True): DailyUniqueViews,
+        (False, False): DailyViews,
     }
-
-    if complete:
-        indicator = DailyCompletedViews(**indicator_kwargs)
-    else:
-        indicator = DailyViews(**indicator_kwargs)
+    indicator = klass_mapping.get((complete, unique), DailyViews)(
+        video_id=video_id, span_range=DatetimeRange.parse_obj(filters)
+    )
+    logger.debug("Will compute indicator %s", indicator)
 
     try:
-        return await indicator.compute()
+        results = await indicator.get_or_compute()
     except (KeyError, AttributeError, LrsClientException) as exception:
         message = "An error occurred while computing the number of views"
         logger.error("%s: %s", message, exception)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message
         ) from exception
+
+    if isinstance(results, DailyUniqueCounts):
+        results = results.to_daily_counts()
+    logger.debug("results = %s", results)
+    return results
 
 
 @router.get("/{video_id:path}/downloads")
@@ -55,17 +68,22 @@ async def downloads(
     unique: bool = False,
 ) -> DailyCounts:
     """Number of downloads for `video_id` in the `since` -> `until` date range."""
-    indicator = DailyDownloads(
-        video_id=video_id,
-        date_range=DatetimeRange.parse_obj(filters),
-        unique=unique,
+    indicator_klass = DailyUniqueDownloads if unique else DailyDownloads
+    indicator = indicator_klass(
+        video_id=video_id, span_range=DatetimeRange.parse_obj(filters)
     )
+    logger.debug("Will compute indicator %s", indicator)
 
     try:
-        return await indicator.compute()
+        results = await indicator.get_or_compute()
     except (KeyError, AttributeError, LrsClientException) as exception:
         message = "An error occurred while computing the number of downloads"
         logger.error("%s: %s", message, exception)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message
         ) from exception
+
+    if isinstance(results, DailyUniqueCounts):
+        results = results.to_daily_counts()
+    logger.debug("results = %s", results)
+    return results


### PR DESCRIPTION
## Purpose

We need to make video indicators cachable.

## Proposal

- [x] improve cached indicator's results serialization
- [x] make video indicators cachable
- [x] create new video indicators for "unique" calculations
  
During this work, we've also decided to make indicators' usage more straightforward. There should be one obvious way to perform a calculation: using a single indicator instance. Maybe this immutability criterion should be enforced even further in a near future.