### PR TITLE
Ensure consistent timezone in DailyEvent indicators

### DIFF
--- a/src/api/core/warren/filters.py
+++ b/src/api/core/warren/filters.py
@@ -58,6 +58,11 @@ class DatetimeRange(BaseModel):
             )
         return values
 
+    @property
+    def tzinfo(self):
+        """Return the shared timezone information of the date range."""
+        return self.since.tzinfo
+
 
 class BaseQueryFilters(DatetimeRange):
     """Common query filters that every API endpoint should implement."""

--- a/src/api/core/warren/tests/test_filters.py
+++ b/src/api/core/warren/tests/test_filters.py
@@ -4,6 +4,7 @@ import datetime
 
 import arrow
 import pytest
+from dateutil.tz import tzoffset, tzutc
 from fastapi import HTTPException
 from freezegun import freeze_time
 from pydantic import ValidationError
@@ -82,6 +83,24 @@ def test_datetime_range_model_defaults(monkeypatch):
 
     period = DatetimeRange(until="2023.01.02")
     assert period.since == period.until - datetime.timedelta(days=7)
+
+
+def test_datetime_range_tzinfo():
+    """Test the DatetimeRange tzinfo property."""
+    period_utc = DatetimeRange(
+        since=arrow.get("2023-01-01"), until=arrow.get("2023-01-02")
+    )
+    assert period_utc.tzinfo == tzutc()
+
+    period_default = DatetimeRange()
+    assert period_default.tzinfo == tzutc()
+
+    period_timezone = DatetimeRange(
+        since=arrow.get("2023-01-01T00:00:00+02:00"),
+        until=arrow.get("2023-01-02T00:00:00+02:00"),
+    )
+    # 7200 seconds is equal to 2 hours
+    assert period_timezone.tzinfo == tzoffset(None, 7200)
 
 
 def test_base_query_filters_model():

--- a/src/api/core/warren/tests/test_xapi.py
+++ b/src/api/core/warren/tests/test_xapi.py
@@ -22,7 +22,7 @@ def test_statements_transformer_normalize():
     assert len(statements) == len(raw_statements)
 
 
-def test_statements_transformer_add_date_column():
+def test_statements_transformer_to_datetime():
     """Test the parsing of 2 simple statements, with the addition of a "date" column."""
     raw_statements = [
         BaseXapiStatementFactory.build(
@@ -34,12 +34,20 @@ def test_statements_transformer_add_date_column():
     ]
 
     statements = StatementsTransformer.normalize(raw_statements)
-    statements = StatementsTransformer.add_date_column(statements)
+    statements = StatementsTransformer.to_datetime(statements)
 
     assert type(statements) is pd.DataFrame
     assert len(statements) == len(raw_statements)
-    assert statements["date"].equals(
-        pd.to_datetime(pd.Series(["2023-01-01", "2023-01-03"], name="date")).dt.date
+    assert statements["timestamp"].equals(
+        pd.to_datetime(
+            pd.Series(
+                [
+                    "2023-01-01T00:10:00.000000+00:00",
+                    "2023-01-03T00:10:00.000000+00:00",
+                ],
+                name="timestamp",
+            )
+        )
     )
 
 
@@ -105,7 +113,7 @@ def test_statements_transformer_add_actor_uid():
     ]
 
     statements = StatementsTransformer.normalize(raw_statements)
-    statements = StatementsTransformer.add_date_column(statements)
+    statements = StatementsTransformer.to_datetime(statements)
     statements = StatementsTransformer.add_actor_uid_column(statements)
 
     assert type(statements) == pd.DataFrame
@@ -183,13 +191,19 @@ def test_statements_transformer_preprocess_statements_workflow():
     assert type(statements) == pd.DataFrame
     assert "actor.uid" in statements.columns
     assert statements["actor.uid"].notna
-    assert statements["date"].equals(
+    assert statements["timestamp"].equals(
         pd.to_datetime(
             pd.Series(
-                ["2023-01-01", "2023-01-02", "2023-01-02", "2023-01-03", "2023-01-03"],
-                name="date",
+                [
+                    "2023-01-01T00:10:00.000000+00:00",
+                    "2023-01-02T00:10:00.000000+00:00",
+                    "2023-01-02T00:10:00.000000+00:00",
+                    "2023-01-03T00:10:00.000000+00:00",
+                    "2023-01-03T00:10:00.000000+00:00",
+                ],
+                name="timestamp",
             )
-        ).dt.date
+        )
     )
     # Check that 2 identical actors have the same UID
     ids_john = statements[statements["actor.account.name"] == "John"]["actor.uid"]

--- a/src/api/core/warren/xapi.py
+++ b/src/api/core/warren/xapi.py
@@ -24,13 +24,10 @@ class StatementsTransformer:
         return pd.json_normalize(statements)
 
     @staticmethod
-    def add_date_column(statements: pd.DataFrame) -> pd.DataFrame:
-        """Add a 'date' column computed from statement's timestamp."""
+    def to_datetime(statements: pd.DataFrame) -> pd.DataFrame:
+        """Convert statement's timestamp from string to datetime."""
         statements = statements.copy()
-        # Disable chained assignment warning to make the transformation inplace
-        with pd.option_context("mode.chained_assignment", None):
-            # Transform 'timestamp' column into a date with the format (YYYY-MM-DD)
-            statements["date"] = pd.to_datetime(statements["timestamp"]).dt.date
+        statements["timestamp"] = pd.to_datetime(statements["timestamp"])
         return statements
 
     @staticmethod
@@ -68,5 +65,5 @@ class StatementsTransformer:
         return pipe(
             StatementsTransformer.normalize,
             StatementsTransformer.add_actor_uid_column,
-            StatementsTransformer.add_date_column,
+            StatementsTransformer.to_datetime,
         )(statements)

--- a/src/api/plugins/video/tests/test_api.py
+++ b/src/api/plugins/video/tests/test_api.py
@@ -112,6 +112,7 @@ async def test_views_backend_query(
     # Define 3 video views fixtures
     video_id = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
     video_views_fixtures = [
+        {"timestamp": "2019-12-31T20:00:00.000+00:00", "time": 100},
         {"timestamp": "2020-01-01T00:00:00.000+00:00", "time": 100},
         {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 200},
         {"timestamp": "2020-01-02T00:00:00.000+00:00", "time": 300},
@@ -149,8 +150,8 @@ async def test_views_backend_query(
     response = await http_client.get(
         url=f"/api/v1/video/{video_id}/views",
         params={
-            "since": "2020-01-01",
-            "until": "2020-01-03",
+            "since": "2020-01-01T00:00:00+05:00",
+            "until": "2020-01-03T23:59:00+05:00",
         },
         headers=auth_headers,
     )
@@ -159,9 +160,9 @@ async def test_views_backend_query(
 
     # Counting all views is expected
     expected_video_views = {
-        "total": 3,
+        "total": 4,
         "counts": [
-            {"date": "2020-01-01", "count": 2},
+            {"date": "2020-01-01", "count": 3},
             {"date": "2020-01-02", "count": 1},
             {"date": "2020-01-03", "count": 0},
         ],
@@ -178,7 +179,7 @@ async def test_unique_views_backend_query(
     # Define 3 video views fixtures
     video_id = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
     video_views_fixtures = [
-        {"timestamp": "2020-01-01T00:00:00.000+00:00", "time": 100},
+        {"timestamp": "2019-12-31T22:00:00.000+00:00", "time": 100},
         {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 200},
         {"timestamp": "2020-01-02T00:00:00.000+00:00", "time": 300},
     ]
@@ -221,8 +222,8 @@ async def test_unique_views_backend_query(
     response = await http_client.get(
         url=f"/api/v1/video/{video_id}/views?unique=true",
         params={
-            "since": "2020-01-01",
-            "until": "2020-01-03",
+            "since": "2020-01-01T00:00:00+02:00",
+            "until": "2020-01-03T23:59:00+02:00",
         },
         headers=auth_headers,
     )
@@ -342,6 +343,7 @@ async def test_downloads_backend_query(
     # Define 3 video downloads fixtures
     video_id = "uuid://ba4252ce-d042-43b0-92e8-f033f45612ee"
     video_download_timestamps = [
+        "2019-12-31T23:00:00.000+00:00",
         "2020-01-01T00:00:00.000+00:00",
         "2020-01-01T00:00:30.000+00:00",
         "2020-01-02T00:00:00.000+00:00",
@@ -378,8 +380,8 @@ async def test_downloads_backend_query(
     response = await http_client.get(
         url=f"/api/v1/video/{video_id}/downloads",
         params={
-            "since": "2020-01-01",
-            "until": "2020-01-03",
+            "since": "2020-01-01T00:00:00+02:00",
+            "until": "2020-01-03T00:00:00+02:00",
         },
         headers=auth_headers,
     )
@@ -388,9 +390,9 @@ async def test_downloads_backend_query(
 
     # Counting all downloads is expected
     expected_video_downloads = {
-        "total": 3,
+        "total": 4,
         "counts": [
-            {"date": "2020-01-01", "count": 2},
+            {"date": "2020-01-01", "count": 3},
             {"date": "2020-01-02", "count": 1},
             {"date": "2020-01-03", "count": 0},
         ],

--- a/src/api/plugins/video/tests/test_indicators.py
+++ b/src/api/plugins/video/tests/test_indicators.py
@@ -9,9 +9,8 @@ from warren.xapi import StatementsTransformer
 from warren_video.indicators import BaseDailyEvent
 
 
-@pytest.mark.anyio
-async def test_base_daily_event_subclass_verb_id():
-    """Test __init_subclass__ for the BaseDailyEvent class."""
+def test_base_daily_event_subclass_verb_id():
+    """Test '__init_subclass__' for the BaseDailyEvent class."""
 
     class MyIndicator(BaseDailyEvent):
         verb_id = "test"

--- a/src/api/plugins/video/tests/test_indicators.py
+++ b/src/api/plugins/video/tests/test_indicators.py
@@ -1,6 +1,11 @@
 """Tests for the video indicators."""
 
+import pandas as pd
 import pytest
+from dateutil.tz import tzoffset
+from warren.factories.base import BaseXapiStatementFactory
+from warren.filters import DatetimeRange
+from warren.xapi import StatementsTransformer
 from warren_video.indicators import BaseDailyEvent
 
 
@@ -19,3 +24,74 @@ async def test_base_daily_event_subclass_verb_id():
             wrong_attribute = "test"
 
     assert str(exception.value) == "Indicators must declare a 'verb_id' class attribute"
+
+
+def test_base_daily_event_date_range_timezone():
+    """Test 'to_date_range_timezone' for the BaseDailyEvent class."""
+    # Create source statements
+    raw_statements = [
+        BaseXapiStatementFactory.build(
+            mutations=[{"timestamp": "2023-01-01T00:10:00.000000+00:00"}]
+        ).dict(),
+        BaseXapiStatementFactory.build(
+            mutations=[{"timestamp": "2023-01-03T00:10:00.000000+00:00"}]
+        ).dict(),
+    ]
+    source_statements = StatementsTransformer.preprocess(raw_statements)
+
+    # Create an indicator with a DateTimeRange in UTC
+    indicator_utc = BaseDailyEvent(
+        date_range=DatetimeRange(since="2023-01-01", until="2023-01-03"),
+        video_id="Test",
+        unique=True,
+    )
+    # Convert statements' timestamp
+    statements = indicator_utc.to_date_range_timezone(source_statements)
+
+    expected_statements = pd.to_datetime(
+        pd.Series(
+            [
+                "2023-01-01T00:10:00+00:00",
+                "2023-01-03T00:10:00+00:00",
+            ],
+            name="timestamp",
+        )
+    )
+
+    # Statements' timestamp should be in UTC.
+    assert statements["timestamp"].equals(expected_statements)
+
+    # Create an indicator with a DateTimeRange in UTC+02:00
+    indicator_with_timezone = BaseDailyEvent(
+        date_range=DatetimeRange(
+            since="2023-01-01T00:00:00+02:00", until="2023-01-03T00:00:00+02:00"
+        ),
+        video_id="Test",
+        unique=True,
+    )
+    # Convert statements' timestamp
+    statements = indicator_with_timezone.to_date_range_timezone(source_statements)
+
+    # Statements' timestamp should be in UTC+02:00
+    assert statements["timestamp"].equals(
+        expected_statements.dt.tz_convert(tzoffset(None, 7200))
+    )
+
+
+def test_base_daily_event_add_date_column():
+    """Test 'add_date_column' for the BaseDailyEvent class."""
+    raw_statements = [
+        BaseXapiStatementFactory.build(
+            mutations=[{"timestamp": "2023-01-01T00:10:00.000000+00:00"}]
+        ).dict(),
+        BaseXapiStatementFactory.build(
+            mutations=[{"timestamp": "2023-01-03T00:10:00.000000+00:00"}]
+        ).dict(),
+    ]
+    source_statements = StatementsTransformer.preprocess(raw_statements)
+    statements = BaseDailyEvent.extract_date_from_timestamp(source_statements)
+
+    assert statements["date"].equals(
+        pd.to_datetime(pd.Series(["2023-01-01", "2023-01-03"], name="date")).dt.date
+    )
+    assert "timestamp" not in statements.columns

--- a/src/frontend/packages/ui/video/utils.ts
+++ b/src/frontend/packages/ui/video/utils.ts
@@ -1,5 +1,8 @@
 import dayjs, { Dayjs } from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { VideoViewsResponse } from "./types";
+
+dayjs.extend(utc);
 
 /**
  * Calculate the total sum of views from an array of VideoViewsResponse objects.
@@ -14,21 +17,6 @@ export const sumViews = (views: VideoViewsResponse[]): number =>
     : 0;
 
 /**
- * Get default start and end dates for a date range.
- * The default range duration is 'DEFAULT_RANGE_DURATION' days.
- *
- * @returns {[string, string]} An array containing the default start and end dates.
- */
-export const getDefaultDates = (): [string, string] => {
-  const DEFAULT_RANGE_DURATION = 7;
-  const endDate = dayjs().endOf("day");
-  const startDate = endDate
-    .subtract(DEFAULT_RANGE_DURATION, "day")
-    .startOf("day");
-  return [startDate, endDate].map((v) => v.format());
-};
-
-/**
  * Format a pair of date values to the start or end of the day.
  *
  * This function takes an array of two date values and formats each date to either the start or end of the day based on its position in the array.
@@ -38,6 +26,27 @@ export const getDefaultDates = (): [string, string] => {
  */
 export const formatDates = (dates: [string | Dayjs, string | Dayjs]) => {
   const formatDay = (d: string | Dayjs, isStart: boolean) =>
-    dayjs(d)[isStart ? "startOf" : "endOf"]("day").format();
-  return dates.map((d, index) => formatDay(d, index === 0));
+    dayjs(d)[isStart ? "startOf" : "endOf"]("day");
+
+  const [startDate, endDate] = dates.map((d, index) =>
+    formatDay(d, index === 0),
+  );
+
+  // FIXME - Handle daylight saving time (DST) and standard time (STD) disparities within the API.
+  return [startDate.utcOffset(endDate.utcOffset(), true), endDate].map((v) =>
+    v.format(),
+  );
+};
+
+/**
+ * Get default start and end dates for a date range.
+ * The default range duration is 'DEFAULT_RANGE_DURATION' days.
+ *
+ * @returns {[string, string]} An array containing the default start and end dates.
+ */
+export const getDefaultDates = (): [string, string] => {
+  const DEFAULT_RANGE_DURATION = 7;
+  const endDate = dayjs();
+  const startDate = endDate.subtract(DEFAULT_RANGE_DURATION, "day");
+  return formatDates([startDate, endDate]);
 };


### PR DESCRIPTION
## Purpose

It closes #114.

## Proposal

- [X] Added checks on 'since' and 'until' timezones.
- [X] Introduced a new property 'tzinfo' in 'DatetimeRange' model.
- [X] Converted statements to the user's timezone before counting statements by day.
- [x] Add tests on new indicator features.


