### PR TITLE
🐛(api) fix views computation

### DIFF
--- a/src/api/plugins/video/tests/test_api.py
+++ b/src/api/plugins/video/tests/test_api.py
@@ -146,9 +146,9 @@ async def test_views_backend_query(
                     ).json(),
                 )
                 for view_data in [
-                    {"timestamp": "2019-12-31T20:00:00.000+00:00", "time": 100},
-                    {"timestamp": "2020-01-01T00:00:00.000+00:00", "time": 100},
-                    {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 200},
+                    {"timestamp": "2019-12-31T20:00:00.000+00:00", "time": 3},
+                    {"timestamp": "2020-01-01T00:00:00.000+00:00", "time": 23},
+                    {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 18},
                 ]
             ]
         elif (
@@ -159,7 +159,7 @@ async def test_views_backend_query(
                 json.loads(
                     LocalVideoPlayedFactory.build(
                         [
-                            {"result": {"extensions": {RESULT_EXTENSION_TIME: 300}}},
+                            {"result": {"extensions": {RESULT_EXTENSION_TIME: 5}}},
                             {"timestamp": "2020-01-02T00:00:00.000+00:00"},
                         ]
                     ).json(),

--- a/src/api/plugins/video/warren_video/indicators.py
+++ b/src/api/plugins/video/warren_video/indicators.py
@@ -210,7 +210,7 @@ class DailyViewsMixin:
         def filter_view_duration(row):
             return (
                 row[f"result.extensions.{RESULT_EXTENSION_TIME}"]
-                >= video_plugin_settings.VIEWS_COUNT_TIME_THRESHOLD
+                <= video_plugin_settings.VIEWS_COUNT_TIME_THRESHOLD
             )
 
         return statements[statements.apply(filter_view_duration, axis=1)]


### PR DESCRIPTION
## Purpose 

Views is computed by counting `played` events generated before a threshold
on the video timeline.

## Proposal

Currently, indicators based on views computation was counting events generated
after this threshold. It has been reversed and tests adapted.
