### PR TITLE
🐛(api) fix Cache mixin database session management

### DIFF
--- a/src/api/core/warren/indicators/mixins.py
+++ b/src/api/core/warren/indicators/mixins.py
@@ -10,7 +10,6 @@ import arrow
 from pydantic.main import BaseModel
 from sqlmodel import Session, select
 
-from warren.db import get_session as get_db_session
 from warren.filters import DatetimeRange
 
 from .models import CacheEntry, CacheEntryCreate
@@ -43,10 +42,7 @@ logger = logging.getLogger(__name__)
 class CacheMixin:
     """A cache mixin that handles indicator persistence."""
 
-    @cached_property
-    def db_session(self) -> Session:
-        """Get the database session singleton."""
-        return next(get_db_session())
+    db_session: Session = None
 
     @cached_property
     def cache_key(self) -> str:

--- a/src/api/core/warren/tests/fixtures/db.py
+++ b/src/api/core/warren/tests/fixtures/db.py
@@ -4,8 +4,9 @@ from alembic import command
 from alembic.config import Config
 from sqlmodel import Session, SQLModel, create_engine
 
+from warren.api.v1 import app as v1
 from warren.conf import settings
-from warren.indicators.mixins import CacheMixin
+from warren.db import get_session
 
 
 @pytest.fixture(scope="session")
@@ -47,7 +48,13 @@ def db_session(db_engine):
     connection.close()
 
 
-@pytest.fixture(autouse=True, scope="function")
-def force_db_test_session(db_session, monkeypatch):
+@pytest.fixture(autouse=True)
+def force_db_test_session(db_session):
     """Use test database along with a test session by default."""
-    monkeypatch.setattr(CacheMixin, "db_session", db_session)
+
+    def get_session_override():
+        return db_session
+
+    v1.dependency_overrides[get_session] = get_session_override
+
+    yield

--- a/src/api/core/warren/tests/test_indicators_mixins.py
+++ b/src/api/core/warren/tests/test_indicators_mixins.py
@@ -82,6 +82,9 @@ async def test_save_with_single_cache_instance(db_session):
     class MyIndicator(CacheMixin, BaseIndicator):
         """Dummy indicator."""
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(query={"verb": "played"})
 
@@ -91,7 +94,7 @@ async def test_save_with_single_cache_instance(db_session):
         async def compute(self):
             pass
 
-    indicator = MyIndicator()
+    indicator = MyIndicator(db_session=db_session)
     caches = db_session.exec(
         select(CacheEntry).where(CacheEntry.key == indicator.cache_key)
     ).all()
@@ -117,6 +120,9 @@ async def test_save_with_multiple_cache_instances(db_session):
     class MyIndicator(CacheMixin, BaseIndicator):
         """Dummy indicator."""
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(query={"verb": "played"})
 
@@ -126,7 +132,7 @@ async def test_save_with_multiple_cache_instances(db_session):
         async def compute(self):
             pass
 
-    indicator = MyIndicator()
+    indicator = MyIndicator(db_session=db_session)
     caches = db_session.exec(
         select(CacheEntry).where(CacheEntry.key == indicator.cache_key)
     ).all()
@@ -162,6 +168,9 @@ async def test_get_cache(db_session):
     class MyIndicatorA(CacheMixin, BaseIndicator):
         """Dummy indicator."""
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(query={"verb": "played"})
 
@@ -174,6 +183,9 @@ async def test_get_cache(db_session):
     class MyIndicatorB(CacheMixin, BaseIndicator):
         """Dummy indicator."""
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(query={"verb": "played"})
 
@@ -183,8 +195,8 @@ async def test_get_cache(db_session):
         async def compute(self):
             pass
 
-    a = MyIndicatorA()
-    b = MyIndicatorB()
+    a = MyIndicatorA(db_session=db_session)
+    b = MyIndicatorB(db_session=db_session)
 
     db_session.add(CacheEntry(key=a.cache_key, value={"foo": [1, 2, 3]}))
     db_session.add(CacheEntry(key=b.cache_key, value={"foo": [4, 5, 6]}))
@@ -205,6 +217,9 @@ async def test_get_cache_when_no_cache_exists(db_session):
     class MyIndicator(CacheMixin, BaseIndicator):
         """Dummy indicator."""
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(query={"verb": "played"})
 
@@ -214,7 +229,7 @@ async def test_get_cache_when_no_cache_exists(db_session):
         async def compute(self):
             pass
 
-    indicator = MyIndicator()
+    indicator = MyIndicator(db_session=db_session)
 
     caches = db_session.exec(
         select(CacheEntry).where(CacheEntry.key == indicator.cache_key)
@@ -230,6 +245,9 @@ async def test_get_cache_when_unexpected_multiple_cache_exist(db_session):
     class MyIndicator(CacheMixin, BaseIndicator):
         """Dummy indicator."""
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(query={"verb": "played"})
 
@@ -239,7 +257,7 @@ async def test_get_cache_when_unexpected_multiple_cache_exist(db_session):
         async def compute(self):
             pass
 
-    indicator = MyIndicator()
+    indicator = MyIndicator(db_session=db_session)
 
     db_session.add(CacheEntry(key=indicator.cache_key, value={"foo": [1, 2, 3]}))
     db_session.add(CacheEntry(key=indicator.cache_key, value={"foo": [4, 5, 6]}))
@@ -257,6 +275,9 @@ def test_compute_annotation():
 
     class MyIndicator(CacheMixin, BaseIndicator):
         """Dummy indicator."""
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
 
         def get_lrs_query(self) -> LRSQuery:
             return None
@@ -364,6 +385,9 @@ async def test_get_or_compute(db_session, monkeypatch):
     class MyIndicator(CacheMixin, BaseIndicator):
         """Dummy indicator."""
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(query={"verb": "played"})
 
@@ -373,7 +397,7 @@ async def test_get_or_compute(db_session, monkeypatch):
         async def compute(self) -> dict:
             return {"foo": [1, 2, 3]}
 
-    indicator = MyIndicator()
+    indicator = MyIndicator(db_session=db_session)
 
     # Check that nothing already exists in the database
     caches = db_session.exec(
@@ -393,6 +417,9 @@ async def test_get_or_compute(db_session, monkeypatch):
     class MyIndicator(CacheMixin, BaseIndicator):
         """Dummy mocked indicator."""
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(query={"verb": "played"})
 
@@ -405,7 +432,7 @@ async def test_get_or_compute(db_session, monkeypatch):
 
         compute = AsyncMock(return_value={"foo": [4, 5, 6]})
 
-    indicator = MyIndicator()
+    indicator = MyIndicator(db_session=db_session)
 
     # Call compute once again and ensure we don't recalculate the results
     result = await indicator.get_or_compute()
@@ -432,6 +459,9 @@ async def test_incremental_get_cache(db_session):
 
         frame = "day"
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(
             self, since: datetime = None, until: datetime = None
         ) -> LRSQuery:
@@ -453,7 +483,8 @@ async def test_incremental_get_cache(db_session):
     indicator = MyDailyIndicator(
         span_range=DatetimeRange(
             since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
-        )
+        ),
+        db_session=db_session,
     )
     # Check that nothing already exists in the database
     caches = db_session.exec(
@@ -497,6 +528,9 @@ async def test_incremental_get_cache_when_multiple_cache_exists(db_session):
 
         frame = "day"
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(
             self, since: datetime = None, until: datetime = None
         ) -> LRSQuery:
@@ -518,7 +552,8 @@ async def test_incremental_get_cache_when_multiple_cache_exists(db_session):
     indicator = MyDailyIndicator(
         span_range=DatetimeRange(
             since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
-        )
+        ),
+        db_session=db_session,
     )
     # Check that nothing already exists in the database
     caches = db_session.exec(
@@ -570,6 +605,9 @@ async def test_incremental_get_cache_limits(db_session):
 
         frame = "day"
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(
             self, since: datetime = None, until: datetime = None
         ) -> LRSQuery:
@@ -591,7 +629,8 @@ async def test_incremental_get_cache_limits(db_session):
     indicator = MyDailyIndicator(
         span_range=DatetimeRange(
             since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
-        )
+        ),
+        db_session=db_session,
     )
     # Check that nothing already exists in the database
     caches = db_session.exec(
@@ -635,6 +674,9 @@ async def test_incremental_get_continuous_cache_for_time_span(db_session):
 
         frame = "day"
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(
             self, since: datetime = None, until: datetime = None
         ) -> LRSQuery:
@@ -656,7 +698,8 @@ async def test_incremental_get_continuous_cache_for_time_span(db_session):
     indicator = MyDailyIndicator(
         span_range=DatetimeRange(
             since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
-        )
+        ),
+        db_session=db_session,
     )
     # Check that nothing already exists in the database
     caches = db_session.exec(
@@ -698,6 +741,9 @@ async def test_incremental_get_continuous_cache_for_time_span_with_week_frame(
 
         frame = "week"
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(
             self, since: datetime = None, until: datetime = None
         ) -> LRSQuery:
@@ -718,7 +764,8 @@ async def test_incremental_get_continuous_cache_for_time_span_with_week_frame(
     indicator = MyWeeklyIndicator(
         span_range=DatetimeRange(
             since=datetime(2023, 5, 12), until=datetime(2023, 7, 24)
-        )
+        ),
+        db_session=db_session,
     )
     # Check that nothing already exists in the database
     caches = db_session.exec(
@@ -883,6 +930,9 @@ async def test_incremental_get_or_compute(db_session):
 
         frame = "day"
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(
                 query={"verb": "played", "since": self.since, "until": self.until}
@@ -906,7 +956,8 @@ async def test_incremental_get_or_compute(db_session):
     indicator = MyDailyIndicator(
         span_range=DatetimeRange(
             since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
-        )
+        ),
+        db_session=db_session,
     )
     # Check that nothing already exists in the database
     caches = db_session.exec(
@@ -967,6 +1018,9 @@ async def test_incremental_get_or_compute_update(db_session):
 
         frame = "day"
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(
                 query={"verb": "played", "since": self.since, "until": self.until}
@@ -990,7 +1044,8 @@ async def test_incremental_get_or_compute_update(db_session):
     indicator = MyDailyIndicator(
         span_range=DatetimeRange(
             since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
-        )
+        ),
+        db_session=db_session,
     )
     # Check that nothing already exists in the database
     caches = db_session.exec(
@@ -1060,6 +1115,9 @@ async def test_incremental_get_or_compute_update_and_create(db_session):
 
         frame = "day"
 
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
         def get_lrs_query(self) -> LRSQuery:
             return LRSQuery(
                 query={"verb": "played", "since": self.since, "until": self.until}
@@ -1083,7 +1141,8 @@ async def test_incremental_get_or_compute_update_and_create(db_session):
     indicator = MyDailyIndicator(
         span_range=DatetimeRange(
             since=datetime(2023, 1, 1), until=datetime(2023, 1, 31)
-        )
+        ),
+        db_session=db_session,
     )
     # Check that nothing already exists in the database
     assert (

--- a/src/api/plugins/video/tests/test_indicators.py
+++ b/src/api/plugins/video/tests/test_indicators.py
@@ -176,7 +176,9 @@ async def test_daily_unique_views(httpx_mock: HTTPXMock, db_session):
     )
 
     span_range = DatetimeRange(since="2020-01-01", until="2020-01-03")
-    indicator = DailyUniqueViews(video_id=video_id, span_range=span_range)
+    indicator = DailyUniqueViews(
+        video_id=video_id, span_range=span_range, db_session=db_session
+    )
     daily_counts = await indicator.get_or_compute()
 
     # Generate an example statement to get default actor uid

--- a/src/api/plugins/video/warren_video/api.py
+++ b/src/api/plugins/video/warren_video/api.py
@@ -2,7 +2,9 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session
 from typing_extensions import Annotated  # python <3.9 compat
+from warren.db import get_session
 from warren.exceptions import LrsClientException
 from warren.fields import IRI
 from warren.filters import BaseQueryFilters, DatetimeRange
@@ -25,10 +27,11 @@ logger = logging.getLogger(__name__)
 
 
 @router.get("/{video_id:path}/views")
-async def views(
+async def views(  # noqa: PLR0913
     video_id: IRI,
     filters: Annotated[BaseQueryFilters, Depends()],
     token: Annotated[LTIToken, Depends(get_lti_token)],
+    session: Annotated[Session, Depends(get_session)],
     complete: bool = False,
     unique: bool = False,
 ) -> DailyCounts:
@@ -41,7 +44,9 @@ async def views(
         (False, False): DailyViews,
     }
     indicator = klass_mapping.get((complete, unique), DailyViews)(
-        video_id=video_id, span_range=DatetimeRange.parse_obj(filters)
+        video_id=video_id,
+        span_range=DatetimeRange.parse_obj(filters),
+        db_session=session,
     )
     logger.debug("Will compute indicator %s", indicator)
 
@@ -65,12 +70,15 @@ async def downloads(
     video_id: IRI,
     filters: Annotated[BaseQueryFilters, Depends()],
     token: Annotated[LTIToken, Depends(get_lti_token)],
+    session: Annotated[Session, Depends(get_session)],
     unique: bool = False,
 ) -> DailyCounts:
     """Number of downloads for `video_id` in the `since` -> `until` date range."""
     indicator_klass = DailyUniqueDownloads if unique else DailyDownloads
     indicator = indicator_klass(
-        video_id=video_id, span_range=DatetimeRange.parse_obj(filters)
+        video_id=video_id,
+        span_range=DatetimeRange.parse_obj(filters),
+        db_session=session,
     )
     logger.debug("Will compute indicator %s", indicator)
 

--- a/src/api/plugins/video/warren_video/indicators.py
+++ b/src/api/plugins/video/warren_video/indicators.py
@@ -28,11 +28,7 @@ class BaseDailyEvent(BaseIndicator, IncrementalCacheMixin):
     frame: str = "day"
     verb_id: str = None
 
-    def __init__(
-        self,
-        video_id: str,
-        span_range: DatetimeRange,
-    ):
+    def __init__(self, video_id: str, span_range: DatetimeRange, **kwargs):
         """Instantiate the Daily Event Indicator.
 
         Args:
@@ -41,8 +37,10 @@ class BaseDailyEvent(BaseIndicator, IncrementalCacheMixin):
                 2 fields, `since` and `until` which are dates or timestamps that must be
                 in ISO format (YYYY-MM-DD, YYYY-MM-DDThh:mm:ss.sss±hh:mm or
                 YYYY-MM-DDThh:mm:ss.sssZ")
+            kwargs (dict): indicator-specific extra arguments that will
+                be stored as indicator attributes.
         """
-        super().__init__(span_range=span_range, video_id=video_id)
+        super().__init__(span_range=span_range, video_id=video_id, **kwargs)
 
     def get_lrs_query(
         self,


### PR DESCRIPTION
## Purpose

Have a proper management of database sessions while using cache.

## Proposal

Resolved issues within Cache mixin classes where database sessions were not being properly closed, resulting in exceptions from SQLAlchemy.

FastAPI is now responsible for acquiring a single database session per request and subsequently closing it after the response is returned. This update ensures proper management of database sessions, preventing to exceed the connections pool size limitations.

In this initial approach, I passed the session as a parameter to the `get_or_compute` method. This simplification removed the Cache mixin's internal state regarding the database session. Wdyt @jmaupetit?


