### PR TITLE
🔧(project) ignore `tests` subfolders for coverage measurement

### DIFF
--- a/src/api/core/pyproject.toml
+++ b/src/api/core/pyproject.toml
@@ -71,10 +71,14 @@ ci = [
 [tool.setuptools.dynamic]
 version = { attr = "warren.__version__" }
 
+[tool.coverage.run]
+omit = [
+    "*/tests/*",
+]
 
 # Third party packages configuration
 [tool.pytest.ini_options]
-addopts = "-v --cov-report term-missing --cov=core --cov=plugins"
+addopts = "-v --cov-config=core/pyproject.toml --cov-report term-missing --cov=core --cov=plugins"
 python_files = [
     "test_*.py",
     "tests.py",

--- a/src/app/pyproject.toml
+++ b/src/app/pyproject.toml
@@ -72,8 +72,14 @@ packages = ["warren", "apps"]
 version = { attr = "warren.__version__" }
 
 # Third party packages configuration
+[tool.coverage.run]
+omit = [
+    "*/tests/*",
+    "tests.py",
+]
+
 [tool.pytest.ini_options]
-addopts = "-v --cov-report term-missing --cov=apps"
+addopts = "-v --cov-config=pyproject.toml --cov-report term-missing --cov=apps"
 python_files = [
     "test_*.py",
     "tests.py",


### PR DESCRIPTION
## Purpose

Coverage measurement is applied on different packages levels, however tests
files are included in the package files. Coverage reporting mentions coverage of
test files which makes non sense.

## Proposal

The `.coveragerc` file allows to custom the coverage configuration and provides
filenames pattern to ignore when coverage measurement is run.

## References

- https://pytest-cov.readthedocs.io/en/latest/config.html
- https://coverage.readthedocs.io/en/latest/config.html#run-omit

