### PR TITLE
➕(app) add whitenoise to serve static files

### DIFF
--- a/src/app/apps/lti/tests/test_lti_config.py
+++ b/src/app/apps/lti/tests/test_lti_config.py
@@ -1,10 +1,18 @@
 """Tests for the LTI configuration view."""
-
-
 import xmltodict
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
+@override_settings(
+    STORAGES={
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
+)
 class LTIConfigViewTestCase(TestCase):
     """Test LTI configuration view."""
 

--- a/src/app/apps/lti/tests/test_lti_request.py
+++ b/src/app/apps/lti/tests/test_lti_request.py
@@ -118,7 +118,17 @@ class LTIRequestViewTestCase(TestCase):
             },
         )
 
-    @override_settings(ALLOWED_HOSTS=["fake-lms.com"])
+    @override_settings(
+        ALLOWED_HOSTS=["fake-lms.com"],
+        STORAGES={
+            "default": {
+                "BACKEND": "django.core.files.storage.FileSystemStorage",
+            },
+            "staticfiles": {
+                "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+            },
+        },
+    )
     def test_views_lti_request_valid(self):
         """Validate that view is correctly rendered."""
         lti_parameters = {

--- a/src/app/apps/lti/tests/test_lti_select.py
+++ b/src/app/apps/lti/tests/test_lti_select.py
@@ -155,7 +155,17 @@ class LTISelectViewTestCase(TestCase):
         self.assertEqual(response.status_code, 403)
         mock_logger.assert_called_with("LTI role is not valid")
 
-    @override_settings(ALLOWED_HOSTS=["fake-lms.com"])
+    @override_settings(
+        ALLOWED_HOSTS=["fake-lms.com"],
+        STORAGES={
+            "default": {
+                "BACKEND": "django.core.files.storage.FileSystemStorage",
+            },
+            "staticfiles": {
+                "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+            },
+        },
+    )
     def test_views_lti_select_valid(self):
         """Validate that view is correctly rendered."""
         lti_parameters = {

--- a/src/app/pyproject.toml
+++ b/src/app/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "psycopg2-binary==2.9.9",
     "sentry-sdk==1.34.0",
     "urllib3==2.0.7",
+    "whitenoise==6.6.0",
 ]
 dynamic = ["version"]
 

--- a/src/app/warren/settings.py
+++ b/src/app/warren/settings.py
@@ -119,8 +119,30 @@ class Base(Configuration):
 
     # Static files (CSS, JavaScript, Images)
     # https://docs.djangoproject.com/en/4.1/howto/static-files/
+    STATIC_ROOT = values.Value(
+        BASE_DIR / Path("static"),
+        environ_name="WARREN_APP_STATIC_ROOT",
+        environ_prefix=None,
+    )
     STATIC_URL = "static/"
     STATICFILES_DIRS = [os.path.join(BASE_DIR, "staticfiles")]
+
+    # Media
+    MEDIA_ROOT = values.Value(
+        BASE_DIR / Path("media"),
+        environ_name="WARREN_APP_MEDIA_ROOT",
+        environ_prefix=None,
+    )
+
+    # Storages
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        },
+    }
 
     # Default primary key field type
     # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
@@ -175,6 +197,7 @@ class Base(Configuration):
 
     MIDDLEWARE = [
         "django.middleware.security.SecurityMiddleware",
+        "whitenoise.middleware.WhiteNoiseMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.middleware.locale.LocaleMiddleware",
         "corsheaders.middleware.CorsMiddleware",
@@ -187,6 +210,7 @@ class Base(Configuration):
 
     # Django applications from the highest priority to the lowest
     INSTALLED_APPS = [
+        "whitenoise.runserver_nostatic",
         "django.contrib.admin",
         "django.contrib.auth",
         "django.contrib.contenttypes",


### PR DESCRIPTION
## Purpose

[Whitenoise](https://whitenoise.readthedocs.io/en/latest/django.html) help serving static files of a Django project. By using this app, we no longer need to serve them with Nginx or alike.

## Proposal

- [x] integrate whitenoise for production
- [x] integrate whitenoise for development
