### PR TITLE
🐛(indicators) fix method inheritance order for views indicators

### DIFF
--- a/src/api/plugins/video/tests/test_api.py
+++ b/src/api/plugins/video/tests/test_api.py
@@ -236,9 +236,9 @@ async def test_unique_views_backend_query(
                 ).json(),
             )
             for view_data in [
-                {"timestamp": "2019-12-31T22:00:00.000+00:00", "time": 100},
-                {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 200},
-                {"timestamp": "2020-01-02T00:00:30.000+00:00", "time": 300},
+                {"timestamp": "2019-12-31T22:00:00.000+00:00", "time": 3},
+                {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 29},
+                {"timestamp": "2020-01-02T00:00:30.000+00:00", "time": 10},
             ]
         ]
 

--- a/src/api/plugins/video/tests/test_indicators.py
+++ b/src/api/plugins/video/tests/test_indicators.py
@@ -143,8 +143,8 @@ async def test_daily_unique_views(httpx_mock: HTTPXMock, db_session):
                     ).json(),
                 )
                 for view_data in [
-                    {"timestamp": "2020-01-01T00:00:00.000+00:00", "time": 100},
-                    {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 200},
+                    {"timestamp": "2020-01-01T00:00:00.000+00:00", "time": 17},
+                    {"timestamp": "2020-01-01T00:00:30.000+00:00", "time": 23},
                 ]
             ]
         elif (

--- a/src/api/plugins/video/warren_video/indicators.py
+++ b/src/api/plugins/video/warren_video/indicators.py
@@ -93,14 +93,12 @@ class BaseDailyEvent(BaseIndicator, IncrementalCacheMixin):
         statements = await self.fetch_statements()
         if not statements:
             return daily_counts
-
         statements = pipe(
             StatementsTransformer.preprocess,
             self.filter_statements,
             self.to_span_range_timezone,
             self.extract_date_from_timestamp,
         )(statements)
-
         # Compute daily counts from 'statements' DataFrame
         # and merge them into the 'daily_counts' object
         daily_counts.merge_counts(
@@ -216,7 +214,7 @@ class DailyViewsMixin:
         return statements[statements.apply(filter_view_duration, axis=1)]
 
 
-class DailyViews(DailyEvent, DailyViewsMixin):
+class DailyViews(DailyViewsMixin, DailyEvent):
     """Daily Views indicator.
 
     Calculate the total and daily counts of views.
@@ -228,7 +226,7 @@ class DailyViews(DailyEvent, DailyViewsMixin):
     verb_id: str = PlayedVerb().id
 
 
-class DailyUniqueViews(DailyUniqueEvent, DailyViewsMixin):
+class DailyUniqueViews(DailyViewsMixin, DailyUniqueEvent):
     """Daily Unique Views indicator.
 
     Calculate the total, unique and daily counts of views.


### PR DESCRIPTION
## Purpose 

Views indicators tests pass for all requested `played` statements.
It has been designed that normally such indicators should only compute on
`played` statements that were generated in the 30 first seconds of a video. 

## Proposal

The mixin used for DailyViews was placed after the DailyEvent class in
inheritance, causing method resolution order issues. By reordering the
inheritance sequence, indicators now correctly inherit methods from the mixin.

