### PR TITLE
✨(api) add health check endpoints

### DIFF
--- a/src/api/core/warren/api/__init__.py
+++ b/src/api/core/warren/api/__init__.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from warren.conf import settings
 
+from .health import router as health_router
 from .v1 import app as v1
 
 app = FastAPI()
@@ -17,4 +18,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Health checks
+app.include_router(health_router)
+
+# Mount v1 API
 app.mount("/api/v1", v1)

--- a/src/api/core/warren/api/health.py
+++ b/src/api/core/warren/api/health.py
@@ -1,0 +1,62 @@
+"""API routes related to application health checking."""
+
+import logging
+from enum import Enum, unique
+
+from fastapi import APIRouter, Response, status
+from pydantic import BaseModel
+from ralph.backends.http.base import HTTPBackendStatus
+
+from warren.backends import lrs_client
+from warren.db import is_alive as is_db_alive
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@unique
+class BackendStatus(str, Enum):
+    """Generic backend statuses inspired from Ralph HTTP backend."""
+
+    OK = "ok"
+    AWAY = "away"
+    ERROR = "error"
+
+
+class Heartbeat(BaseModel):
+    """Warren backends status."""
+
+    database: BackendStatus
+    lrs: HTTPBackendStatus
+
+    @property
+    def is_alive(self):
+        """A helper that checks the overall status."""
+        if self.database == BackendStatus.OK and self.lrs == HTTPBackendStatus.OK:
+            return True
+        return False
+
+
+@router.get("/__lbheartbeat__")
+async def lbheartbeat() -> None:
+    """Load balancer heartbeat.
+
+    Return a 200 when the server is running.
+    """
+    return
+
+
+@router.get("/__heartbeat__", status_code=status.HTTP_200_OK)
+async def heartbeat(response: Response) -> Heartbeat:
+    """Application heartbeat.
+
+    Return a 200 if all checks are successful.
+    """
+    statuses = Heartbeat(
+        database=BackendStatus.OK if is_db_alive() else BackendStatus.ERROR,
+        lrs=await lrs_client.status(),
+    )
+    if not statuses.is_alive:
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    return statuses

--- a/src/api/core/warren/db.py
+++ b/src/api/core/warren/db.py
@@ -1,5 +1,7 @@
 """Warren persistence database connection."""
 
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
 from sqlmodel import Session, create_engine
 
 from .conf import settings
@@ -11,3 +13,14 @@ def get_session() -> Session:
     """Get database session single instance."""
     with Session(engine) as session:
         yield session
+
+
+def is_alive() -> bool:
+    """Check if database connection is alive."""
+    with Session(engine) as session:
+        try:
+            session.exec(text("SELECT 1 as is_alive"))
+            return True
+        except OperationalError:
+            return False
+    return False

--- a/src/api/core/warren/tests/test_api_health.py
+++ b/src/api/core/warren/tests/test_api_health.py
@@ -1,0 +1,61 @@
+"""Tests for the health check endpoints."""
+import pytest
+from ralph.backends.http.base import HTTPBackendStatus
+
+from warren.api import health
+from warren.backends import lrs_client
+
+
+@pytest.mark.anyio
+async def test_api_health_lbheartbeat(http_client):
+    """Test the load balancer heartbeat healthcheck."""
+    response = await http_client.get("/__lbheartbeat__")
+    assert response.status_code == 200
+    assert response.json() is None
+
+
+@pytest.mark.anyio
+async def test_api_health_heartbeat(http_client, monkeypatch):
+    """Test the heartbeat healthcheck."""
+
+    async def lrs_ok():
+        return HTTPBackendStatus.OK
+
+    async def lrs_away():
+        return HTTPBackendStatus.AWAY
+
+    async def lrs_error():
+        return HTTPBackendStatus.ERROR
+
+    with monkeypatch.context() as lrs_context:
+        lrs_context.setattr(lrs_client, "status", lrs_ok)
+        response = await http_client.get("/__heartbeat__")
+        assert response.status_code == 200
+        assert response.json() == {"database": "ok", "lrs": "ok"}
+
+        lrs_context.setattr(lrs_client, "status", lrs_away)
+        response = await http_client.get("/__heartbeat__")
+        assert response.json() == {"database": "ok", "lrs": "away"}
+        assert response.status_code == 500
+
+        lrs_context.setattr(lrs_client, "status", lrs_error)
+        response = await http_client.get("/__heartbeat__")
+        assert response.json() == {"database": "ok", "lrs": "error"}
+        assert response.status_code == 500
+
+    with monkeypatch.context() as db_context:
+        lrs_context.setattr(lrs_client, "status", lrs_ok)
+        db_context.setattr(health, "is_db_alive", lambda: False)
+        response = await http_client.get("/__heartbeat__")
+        assert response.json() == {"database": "error", "lrs": "ok"}
+        assert response.status_code == 500
+
+        db_context.setattr(lrs_client, "status", lrs_away)
+        response = await http_client.get("/__heartbeat__")
+        assert response.json() == {"database": "error", "lrs": "away"}
+        assert response.status_code == 500
+
+        db_context.setattr(lrs_client, "status", lrs_error)
+        response = await http_client.get("/__heartbeat__")
+        assert response.json() == {"database": "error", "lrs": "error"}
+        assert response.status_code == 500

--- a/src/api/core/warren/tests/test_db.py
+++ b/src/api/core/warren/tests/test_db.py
@@ -1,0 +1,16 @@
+"""Tests for Warren db module."""
+from sqlalchemy.exc import OperationalError
+from sqlmodel import Session
+
+from warren.db import is_alive
+
+
+def test_db_is_alive(monkeypatch):
+    """Test the database is_alive status chech."""
+    assert is_alive() is True
+
+    def raise_operational_error(*args, **kwargs):
+        raise OperationalError(None, None, None)
+
+    monkeypatch.setattr(Session, "exec", raise_operational_error)
+    assert is_alive() is False


### PR DESCRIPTION
## Purpose

When deploying an application in production (e.g. in a Kubernetes environment), we need a way to check its status so that we can restart it if required.

## Proposal

We've implemented [Mozilla's Dockerflow](https://github.com/mozilla-services/Dockerflow) endpoints.

- [x]  add `__hearbeat__` and `__lbheartbeat__` API endpoints
- [x] add tests for database status check