### PR TITLE
🩹(api) redefine API logging configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,14 +46,12 @@ services:
       - "core.warren.api:app"
       - "--proxy-headers"
       - "--log-config"
-      - "core/logging-config.yaml"
+      - "core/logging-config.dev.yaml"
       - "--host"
       - "0.0.0.0"
       - "--port"
       - "${WARREN_API_SERVER_PORT:-8100}"
       - "--reload"
-      - "--log-level"
-      - "debug"
     volumes:
       - ./src/api:/app
       - ./bin/patch_statements_date.py:/opt/src/patch_statements_date.py

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -76,7 +76,7 @@ CMD ["uvicorn", \
      "warren.api:app", \
      "--proxy-headers", \
      "--log-config", \
-     "core/logging-config.yaml", \
+     "core/logging-config.prod.yaml", \
      "--host", \
      "0.0.0.0", \
      "--port", \
@@ -92,7 +92,7 @@ CMD ["uvicorn", \
      "warren.api:app", \
      "--proxy-headers", \
      "--log-config", \
-     "core/logging-config.yaml", \
+     "core/logging-config.prod.yaml", \
      "--host", \
      "0.0.0.0", \
      "--port", \

--- a/src/api/core/logging-config.dev.yaml
+++ b/src/api/core/logging-config.dev.yaml
@@ -1,0 +1,44 @@
+---
+version: 1
+disable_existing_loggers: false
+formatters:
+  default:
+    "()": uvicorn.logging.DefaultFormatter
+    fmt: "%(levelprefix)s %(message)s"
+    use_colors: true
+  access:
+    "()": uvicorn.logging.AccessFormatter
+    fmt: '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
+    use_colors: true
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
+loggers:
+  uvicorn:
+    handlers:
+      - default
+    level: INFO
+    propagate: false
+  uvicorn.error:
+    level: INFO
+  uvicorn.access:
+    handlers:
+      - access
+    level: INFO
+    propagate: false
+  core.warren.api.v1:
+    handlers:
+      - default
+    level: DEBUG
+    propagate: false
+  warren_video.api:
+    handlers:
+      - default
+    level: DEBUG
+    propagate: false

--- a/src/api/core/logging-config.prod.yaml
+++ b/src/api/core/logging-config.prod.yaml
@@ -32,13 +32,3 @@ loggers:
       - access
     level: INFO
     propagate: false
-  core.warren.api.v1:
-    handlers:
-      - default
-    level: INFO
-    propagate: false
-  warren_video.api:
-    handlers:
-      - default
-    level: INFO
-    propagate: false


### PR DESCRIPTION
## Purpose

Offer developers to access debug logs while developing.

## Proposal

Replaced '--log-level' option with dedicated configs for development and production. Previously, setting logging levels affected only uvicorn logs, not custom loggers. Now, two distinct files manage logging. One for each environment.
