### PR TITLE
🚑️(frontend) fix static files serving

### DIFF
--- a/src/app/warren/settings.py
+++ b/src/app/warren/settings.py
@@ -173,7 +173,7 @@ class Base(Configuration):
             "BACKEND": "django.core.files.storage.FileSystemStorage",
         },
         "staticfiles": {
-            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+            "BACKEND": "whitenoise.storage.CompressedStaticFilesStorage",
         },
     }
 

--- a/src/frontend/apps/web/vite.config.ts
+++ b/src/frontend/apps/web/vite.config.ts
@@ -12,5 +12,6 @@ export default defineConfig({
         assetFileNames: `assets/[name].[ext]`,
       },
     },
+    reportCompressedSize: false,
   },
 });


### PR DESCRIPTION

## Purpose

Fix rendering in the pre-production demo on moodle.

## Proposal

Disabled manifest generation in Django Whitenoise and turned off output compression in Vite Rollup configuration. This ensures that each tool focuses on its specific responsibilities.

Whitenoise's file hashing was conflicting with Vite's code splitting. Vite's unique chunk filenames make Whitenoise's cache sufficient for handling.
