### PR TITLE
🐛(api) force single database engine and session per thread

### DIFF
--- a/src/api/core/warren/api/__init__.py
+++ b/src/api/core/warren/api/__init__.py
@@ -1,13 +1,25 @@
 """Warren API root."""
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from warren.conf import settings
+from warren.db import get_engine
 
 from .health import router as health_router
 from .v1 import app as v1
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application life span."""
+    engine = get_engine()
+    yield
+    engine.dispose()
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 app.add_middleware(

--- a/src/api/core/warren/db.py
+++ b/src/api/core/warren/db.py
@@ -1,29 +1,76 @@
 """Warren persistence database connection."""
+import logging
+from typing import Optional
 
-from typing import Generator
-
+from sqlalchemy import Engine as SAEngine
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import Session as SASession
-from sqlmodel import Session, create_engine
+from sqlmodel import Session as SMSession
+from sqlmodel import create_engine
 
 from .conf import settings
 
-engine = create_engine(settings.DATABASE_URL, echo=settings.DEBUG)
+logger = logging.getLogger(__name__)
 
 
-def get_session() -> Generator[Session, None, None]:
-    """Get database session single instance."""
-    with Session(engine) as session:
-        yield session
+class Singleton(type):
+    """Singleton pattern metaclass."""
+
+    _instances: dict = {}
+
+    def __call__(cls, *args, **kwargs):
+        """Store instances in a private class property."""
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class Engine(metaclass=Singleton):
+    """Database engine singleton."""
+
+    _engine: Optional[SAEngine] = None
+
+    def get_engine(self, url, echo=False) -> SAEngine:
+        """Get created engine or create a new one."""
+        if self._engine is None:
+            logger.debug("Create a new engine")
+            self._engine = create_engine(url, echo=echo)
+        logger.debug("Getting database engine %s", self._engine)
+        return self._engine
+
+
+class Session(metaclass=Singleton):
+    """Database session singleton."""
+
+    _session: Optional[SMSession] = None
+
+    def get_session(self, engine) -> SMSession:
+        """Get active session or create a new one."""
+        if self._session is None:
+            logger.debug("Create new session")
+            self._session = SMSession(bind=engine)
+        logger.debug("Getting database session %s", self._session)
+        return self._session
+
+
+def get_engine() -> SAEngine:
+    """Get database engine."""
+    return Engine().get_engine(url=settings.DATABASE_URL, echo=settings.DEBUG)
+
+
+def get_session() -> SMSession:
+    """Get database session."""
+    session = Session().get_session(get_engine())
+    logger.debug("Getting session %s", session)
+    return session
 
 
 def is_alive() -> bool:
     """Check if database connection is alive."""
-    with SASession(engine) as session:
-        try:
-            session.execute(text("SELECT 1 as is_alive"))
-            return True
-        except OperationalError:
-            return False
+    session = get_session()
+    try:
+        session.execute(text("SELECT 1 as is_alive"))
+        return True
+    except OperationalError:
+        return False
     return False

--- a/src/api/core/warren/indicators/mixins.py
+++ b/src/api/core/warren/indicators/mixins.py
@@ -55,10 +55,12 @@ class Cacheable(Protocol):
 class CacheMixin(Cacheable):
     """A cache mixin that handles indicator persistence."""
 
-    @cached_property
+    @property
     def db_session(self) -> Session:
         """Get the database session singleton."""
-        return next(get_db_session())
+        session = get_db_session()
+        logger.debug("Indicator session: %s", session.__dict__)
+        return session
 
     @cached_property
     def cache_key(self) -> str:


### PR DESCRIPTION
## Purpose

We've observed connection issues to the PostgreSQL server when many requests are send in parallel.

## Proposal

Use the singleton pattern to avoid opening too many connections to the database and reach the maximal connection pool for database requests during API heavy load.