### PR TITLE
⏪️(project) downgrade Python release for development stack

### DIFF
--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM python:3.12.0-slim as base
+FROM python:3.11-slim as base
 
 # Upgrade pip to its latest release to speed up dependencies installation
 RUN pip install --upgrade pip

--- a/src/app/Dockerfile
+++ b/src/app/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM python:3.12.0-slim as base
+FROM python:3.11-slim as base
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
## Purpose

Development stack has been recently upgraded to Python 3.12.
However, warren image builds takes more than 10 minutes because of wheels for
pandas package that are not available for pandas 2.0.3. (that we have pinned
as the latest release supporting Python 3.8).

## Proposal

Rollback Python dev release to Python 3.11

