### PR TITLE
🔧(backend) deprecate support for Python v3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -587,7 +587,7 @@ workflows:
       - build-api:
           matrix:
             parameters:
-              python-image: [python:3.8, python:3.9, python:3.10, python:3.11, python:3.12]
+              python-image: [python:3.9, python:3.10, python:3.11, python:3.12]
           filters:
             tags:
               only: /.*/
@@ -600,7 +600,7 @@ workflows:
       - test-api:
           matrix:
             parameters:
-              python-image: [python:3.8, python:3.9, python:3.10, python:3.11, python:3.12]
+              python-image: [python:3.9, python:3.10, python:3.11, python:3.12]
           requires:
             - build-api
           filters:
@@ -614,7 +614,7 @@ workflows:
       - build-app:
           matrix:
             parameters:
-              python-image: [python:3.8, python:3.9, python:3.10, python:3.11, python:3.12]
+              python-image: [python:3.9, python:3.10, python:3.11, python:3.12]
           filters:
             tags:
               only: /.*/
@@ -627,7 +627,7 @@ workflows:
       - test-app:
           matrix:
             parameters:
-              python-image: [python:3.8, python:3.9, python:3.10, python:3.11, python:3.12]
+              python-image: [python:3.9, python:3.10, python:3.11, python:3.12]
           requires:
             - build-app
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to
 - Use concise names in indicator and models
 - Refactor the LRS client to be asynchronous
 - Fix count of 0 in all video endpoints
-- Require Python minimum version of 3.8
+- Require Python minimum version of 3.9
 - Encapsulate statements pre-processing in a Mixin class
 - Factorize Video indicators
 

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,6 @@
   "commitMessagePrefix": "⬆️(project)",
   "commitMessageAction": "upgrade",
   "commitBodyTable": true,
-  "ignoreDeps": ["pydantic", "dev/ipython", "dev/pytest-httpx", "dev/httpx", "pandas"],
+  "ignoreDeps": ["pydantic", "dev/pytest-httpx", "dev/httpx"],
   "dependencyDashboard": true
 }

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM python:3.11-slim as base
+FROM python:3.12-slim as base
 
 # Upgrade pip to its latest release to speed up dependencies installation
 RUN pip install --upgrade pip

--- a/src/api/core/pyproject.toml
+++ b/src/api/core/pyproject.toml
@@ -18,13 +18,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE.md"}
 keywords = ["Analytics", "xAPI", "LRS", "LTI"]
 dependencies = [
@@ -34,7 +33,7 @@ dependencies = [
     "elasticsearch[async]==8.11.0",
     "fastapi==0.104.1",
     "importlib-metadata==6.8.0",
-    "pandas==2.0.3",
+    "pandas==2.1.3",
     "psycopg2-binary==2.9.9",
     "pydantic[dotenv]==1.10.13",
     "python-jose[cryptography]==3.3.0",
@@ -59,14 +58,14 @@ dev = [
     "freezegun==1.2.2",
     "httpx==0.24.1",
     "ipdb==0.13.13",
-    "ipython==8.10.0",
+    "ipython==8.18.1",
     "polyfactory==2.12.0",
     "pytest==7.4.3",
     "pytest-cov==4.1.0",
     "pytest-httpx==0.22.0",
     "ruff==0.1.6",
     "mypy==1.7.0",
-    "pandas-stubs==2.0.3.230814",
+    "pandas-stubs==2.1.1.230928",
     "types-python-jose==3.3.4.8"
 ]
 ci = [
@@ -114,8 +113,8 @@ select = [
     "W",  # pycodestyle warning
 ]
 
-# Assume Python 3.8.
-target-version = "py38"
+# Assume Python 3.9.
+target-version = "py39"
 
 [tool.ruff.per-file-ignores]
 "*/tests/*" = [

--- a/src/api/plugins/video/pyproject.toml
+++ b/src/api/plugins/video/pyproject.toml
@@ -18,13 +18,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE.md"}
 keywords = ["Analytics", "xAPI", "LRS", "LTI", "Video"]
 dependencies = [

--- a/src/app/Dockerfile
+++ b/src/app/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM python:3.11-slim as base
+FROM python:3.12-slim as base
 
 ENV PYTHONUNBUFFERED=1
 

--- a/src/app/pyproject.toml
+++ b/src/app/pyproject.toml
@@ -19,13 +19,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE.md"}
 keywords = ["Analytics", "xAPI", "LRS", "LTI"]
 dependencies = [
@@ -55,7 +54,7 @@ dev = [
     "factory-boy==3.3.0",
     "Faker==20.1.0",
     "ipdb==0.13.13",
-    "ipython==8.10.0",
+    "ipython==8.18.1",
     "pytest==7.4.3",
     "pytest-cov==4.1.0",
     "pytest-django==4.7.0",
@@ -106,8 +105,8 @@ select = [
 ]
 exclude = ["apps/*/migrations/*"]
 
-# Assume Python 3.8.
-target-version = "py38"
+# Assume Python 3.9.
+target-version = "py39"
 
 [tool.ruff.per-file-ignores]
 "*/tests/*" = [


### PR DESCRIPTION
## Purpose

Python v3.8 is deprecated in one year, and no longer a requirement for Warren.

## Proposal

- [x] Dropped build and testing of v3.8 Python images for both the api and the app.
- [x] Enabled `Ipython` and `pandas` to be checked by renovate-bot.
- [x] Updated relevant dependencies.
- [x] Updated development Python images to 3.12.

Please note that `ralph-malph` v3.9 is still blocking `pytest-httpx` and `httpx` dependencies to their actual pinned versions.

