### PR TITLE
🩹(api) fix capitalization issue for Django pinned renovate dependency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,6 @@
   "commitMessagePrefix": "⬆️(project)",
   "commitMessageAction": "upgrade",
   "commitBodyTable": true,
-  "ignoreDeps": ["pydantic", "dev/pytest-httpx", "dev/httpx", "django"],
+  "ignoreDeps": ["pydantic", "dev/pytest-httpx", "dev/httpx", "Django"],
   "dependencyDashboard": true
 }


### PR DESCRIPTION
## Purpose

Make renovate ignores Django

## Proposal

Renovate runs an exact match on deps.

- [ ] Updated renovate.json file.
- [ ] Fixed capitalization issue for Django dependency.