### PR TITLE
➖(api) remove unused factory-boy and faker

### DIFF
--- a/src/api/core/pyproject.toml
+++ b/src/api/core/pyproject.toml
@@ -53,8 +53,6 @@ dynamic = ["version"]
 dev = [
     "black==23.11.0",
     "build==1.0.3",
-    "factory-boy==3.3.0",
-    "Faker==20.1.0",
     "freezegun==1.3.1",
     "httpx==0.24.1",
     "ipdb==0.13.13",


### PR DESCRIPTION
## Purpose

Development dependencies need a clean up.

## Proposal

Factory boy is not used at all. We choose Polyfactory.

Faker is second degree dependency of Polyfactory. There is no need to pin or handle it as first degree dependency.
