### PR TITLE
🚀(api) remove useless sources from docker images

### DIFF
--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -38,8 +38,8 @@ FROM base as core
 
 COPY --from=core-builder /usr/local /usr/local
 
-# Copy all sources, not only runtime-required files
-COPY . /app/
+# Copy only run-time required default configurations
+COPY ./core/logging-config.prod.yaml /app/core/
 
 WORKDIR /app
 


### PR DESCRIPTION
## Purpose

Production images are distributed with application sources (copied in the `/app` directory), but it's not required to run the application as warren core and plugins are installed in the installed Python's distribution.

As a side effect, the core Docker image was embedded along with all official plugins, not only core sources.

## Proposal

- [x] Only copy runtime required default configuration files in the `/app` directory
