### PR TITLE
Distribute API database migrations

### DIFF
--- a/bin/alembic
+++ b/bin/alembic
@@ -6,4 +6,4 @@ DOCKER_USER="$(id -u):$(id -g)"
 DOCKER_USER=${DOCKER_USER} docker compose run \
   --rm \
   api \
-  alembic -c core/alembic.ini "$@"
+  alembic -c core/warren/alembic.ini "$@"

--- a/src/api/core/pyproject.toml
+++ b/src/api/core/pyproject.toml
@@ -70,6 +70,9 @@ ci = [
     "twine==4.0.2",
 ]
 
+[project.scripts]
+warren = "warren.commands:main"
+
 [tool.setuptools.dynamic]
 version = { attr = "warren.__version__" }
 

--- a/src/api/core/pyproject.toml
+++ b/src/api/core/pyproject.toml
@@ -73,6 +73,9 @@ ci = [
 [tool.setuptools.dynamic]
 version = { attr = "warren.__version__" }
 
+[tool.setuptools.package-data]
+warren = ["alembic.ini"]
+
 [tool.coverage.run]
 omit = [
     "*/tests/*",

--- a/src/api/core/warren/alembic.ini
+++ b/src/api/core/warren/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = core/warren/migrations
+script_location = %(here)s/migrations
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/src/api/core/warren/commands.py
+++ b/src/api/core/warren/commands.py
@@ -1,0 +1,71 @@
+"""warren-api script."""
+
+import argparse
+import copy
+import sys
+from typing import List
+
+from warren import migrations
+
+
+def get_command_line_parser():
+    """Get command line arguments parser."""
+    parser = argparse.ArgumentParser(prog="warren")
+
+    # Migrations
+    alembic = parser.add_subparsers(title="Database migrations")
+
+    current = alembic.add_parser("current", help="display the current migration")
+    current.add_argument(
+        "-v",
+        "--verbose",
+        default=False,
+        action="store_true",
+        help="verbose mode",
+    )
+    current.set_defaults(func=migrations.current, verbose=False)
+    downgrade = alembic.add_parser(
+        "downgrade", help="downgrade to a specific migration"
+    )
+    downgrade.add_argument(
+        "revision", type=str, help="the target migration to downgrade to"
+    )
+    downgrade.set_defaults(func=migrations.downgrade)
+    history = alembic.add_parser("history", help="display migrations history")
+    history.add_argument(
+        "-v",
+        "--verbose",
+        default=False,
+        action="store_true",
+        help="verbose mode",
+    )
+    history.set_defaults(func=migrations.history, verbose=False)
+    upgrade = alembic.add_parser("upgrade", help="upgrade to a specific migration")
+    upgrade.add_argument(
+        "revision",
+        type=str,
+        default="head",
+        nargs="?",
+        help="the target migration to upgrade to (default: head)",
+    )
+    upgrade.set_defaults(func=migrations.upgrade)
+
+    return parser
+
+
+def main(cmd: List[str]):
+    """Warren command line."""
+    parser = get_command_line_parser()
+    args = parser.parse_args(cmd)
+    params = vars(copy.copy(args))
+
+    if not params:
+        parser.print_help()
+
+    if hasattr(args, "func"):
+        del params["func"]
+        args.func(**params)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/src/api/core/warren/migrations/__init__.py
+++ b/src/api/core/warren/migrations/__init__.py
@@ -1,0 +1,29 @@
+"""Database migrations helpers."""
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+ROOT_PATH: Path = Path(__file__).parent.parent
+ALEMBIC_CFG: Config = Config(ROOT_PATH / "alembic.ini")
+
+
+def current(verbose: bool = False):
+    """Get information about the current migration state."""
+    command.current(ALEMBIC_CFG, verbose=verbose)
+
+
+def downgrade(revision: str):
+    """Downgrade database schema."""
+    command.downgrade(ALEMBIC_CFG, revision)
+
+
+def history(verbose: bool = False):
+    """Get migrations history."""
+    command.history(ALEMBIC_CFG, verbose=verbose)
+
+
+def upgrade(revision: str = "head"):
+    """Upgrade database schema."""
+    command.upgrade(ALEMBIC_CFG, revision)

--- a/src/api/core/warren/tests/fixtures/db.py
+++ b/src/api/core/warren/tests/fixtures/db.py
@@ -19,7 +19,7 @@ def db_engine():
     SQLModel.metadata.create_all(engine)
 
     # Pretend to have all migrations applied
-    alembic_cfg = Config("core/alembic.ini")
+    alembic_cfg = Config("core/warren/alembic.ini")
     command.stamp(alembic_cfg, "head")
 
     yield engine

--- a/src/api/core/warren/tests/test_commands.py
+++ b/src/api/core/warren/tests/test_commands.py
@@ -1,0 +1,130 @@
+"""Test Warren commands functions."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from alembic import command as alembic_command
+
+from warren import commands, migrations
+
+
+def test_get_command_line_parser(capsys):
+    """Test warren commands parser."""
+    parser = commands.get_command_line_parser()
+
+    # No argument passed
+    parsed = parser.parse_args([])
+    assert vars(parsed) == {}
+
+    # Unkown argument should raise a SystemExit error
+    with pytest.raises(SystemExit):
+        parser.parse_args(["-foo"])
+    captured = capsys.readouterr()
+    assert "unrecognized arguments: -foo" in captured.err
+
+    # Unkown command should raise a SystemExit error
+    with pytest.raises(SystemExit):
+        parser.parse_args(["foo"])
+    captured = capsys.readouterr()
+    assert "invalid choice: 'foo'" in captured.err
+
+    # Command: current
+    parsed = parser.parse_args(["current"])
+    assert parsed.verbose is False
+    assert parsed.func == migrations.current
+
+    parsed = parser.parse_args(["current", "-v"])
+    assert parsed.verbose is True
+    assert parsed.func == migrations.current
+
+    parsed = parser.parse_args(["current", "--verbose"])
+    assert parsed.verbose is True
+    assert parsed.func == migrations.current
+
+    # Command: downgrade
+    with pytest.raises(SystemExit):
+        parser.parse_args(["downgrade"])
+    captured = capsys.readouterr()
+    assert "the following arguments are required: revision" in captured.err
+
+    parsed = parser.parse_args(["downgrade", "123abc"])
+    assert parsed.revision == "123abc"
+    assert parsed.func == migrations.downgrade
+
+    # Command: history
+    parsed = parser.parse_args(["history"])
+    assert parsed.verbose is False
+    assert parsed.func == migrations.history
+
+    parsed = parser.parse_args(["history", "-v"])
+    assert parsed.verbose is True
+    assert parsed.func == migrations.history
+
+    parsed = parser.parse_args(["history", "--verbose"])
+    assert parsed.verbose is True
+    assert parsed.func == migrations.history
+
+    # Command: upgrade
+    parsed = parser.parse_args(["upgrade"])
+    assert parsed.revision == "head"
+    assert parsed.func == migrations.upgrade
+
+    parsed = parser.parse_args(["upgrade", "123abc"])
+    assert parsed.revision == "123abc"
+    assert parsed.func == migrations.upgrade
+
+
+def test_warren_command(capsys):
+    """Test warren command call without subcommands."""
+    commands.main([])
+    captured = capsys.readouterr()
+    assert captured.out.startswith(
+        "usage: warren [-h] {current,downgrade,history,upgrade}"
+    )
+
+
+def test_current_command(monkeypatch):
+    """Test warren current command."""
+    monkeypatch.setattr(alembic_command, "current", MagicMock())
+
+    commands.main(["current"])
+    alembic_command.current.assert_called_with(migrations.ALEMBIC_CFG, verbose=False)
+
+    commands.main(["current", "-v"])
+    alembic_command.current.assert_called_with(migrations.ALEMBIC_CFG, verbose=True)
+
+    commands.main(["current", "--verbose"])
+    alembic_command.current.assert_called_with(migrations.ALEMBIC_CFG, verbose=True)
+
+
+def test_downgrade_command(monkeypatch):
+    """Test warren downgrade command."""
+    monkeypatch.setattr(alembic_command, "downgrade", MagicMock())
+
+    commands.main(["downgrade", "123abc"])
+    alembic_command.downgrade.assert_called_with(migrations.ALEMBIC_CFG, "123abc")
+
+
+def test_history_command(monkeypatch):
+    """Test warren history command."""
+    monkeypatch.setattr(alembic_command, "history", MagicMock())
+
+    commands.main(["history"])
+    alembic_command.history.assert_called_with(migrations.ALEMBIC_CFG, verbose=False)
+
+    commands.main(["history", "-v"])
+    alembic_command.history.assert_called_with(migrations.ALEMBIC_CFG, verbose=True)
+
+    commands.main(["history", "--verbose"])
+    alembic_command.history.assert_called_with(migrations.ALEMBIC_CFG, verbose=True)
+
+
+def test_upgrade_command(monkeypatch):
+    """Test warren upgrade command."""
+    monkeypatch.setattr(alembic_command, "upgrade", MagicMock())
+
+    commands.main(["upgrade"])
+    alembic_command.upgrade.assert_called_with(migrations.ALEMBIC_CFG, "head")
+
+    commands.main(["upgrade", "123abc"])
+    alembic_command.upgrade.assert_called_with(migrations.ALEMBIC_CFG, "123abc")


### PR DESCRIPTION
## Purpose

When installing Warren API python package, one need to be able to run database-related operations (migrations) using alembic. As alembic requires a per-project configuration, we need to distribute alembic configuration in the API core python package, and provide a wrapper script that runs alembic behind the scene.

## Proposal

- [x] move alembic configuration file
- [x] add alembic configuration to python package
- [x] add warren CLI for database migrations
- [x] add tests for the command line parser
