### PR TITLE
🐛(api) fix seeding the Experience Index

### DIFF
--- a/bin/seed_experience_index.py
+++ b/bin/seed_experience_index.py
@@ -24,7 +24,7 @@ def seed_experience_index():
     """
 
     # Get a database session
-    session = next(get_session())
+    session = get_session()
 
     # Pass the database session to the factory
     ExperienceFactory.__session__ = session


### PR DESCRIPTION
The function now returns a classic value. This was not considered in the recent rebase of the branch.