### PR TITLE
🐛(api) fix docker development image

### DIFF
--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -52,6 +52,9 @@ COPY --from=full-builder /usr/local /usr/local
 # -- Development --
 FROM full as development
 
+# Copy all sources, not only runtime-required files
+COPY . /app/
+
 # Uninstall warren and re-install it in editable mode along with development
 # dependencies
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Purpose

Docker image build for development is broken:

```
 => ERROR [development 2/2] RUN pip install -e ./core[dev] &&     for plu  0.9s
------
 > [development 2/2] RUN pip install -e ./core[dev] &&     for plugin in ./plugins/*; do         pip install -e "${plugin}[dev]";     done:
#0 0.764 Obtaining file:///app/core
#0 0.765 ERROR: file:///app/core does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
------
failed to solve: process "/bin/bash -o pipefail -c pip install -e ./core[dev] &&     for plugin in ./plugins/*; do         pip install -e \"${plugin}[dev]\";     done" did not complete successfully: exit code: 1
```

We introduced this regression in #173.

## Proposal

- [x] Copy api sources during the development stage to install the core package and plugins in editable mode.
