### PR TITLE
🐛(api) fix XI seeding script

### DIFF
--- a/bin/seed_experience_index.py
+++ b/bin/seed_experience_index.py
@@ -2,16 +2,13 @@
 
 import logging
 
-from sqlmodel import Session, select
+from sqlmodel import select
 
 from sqlalchemy.exc import SQLAlchemyError
 
 from warren.db import get_session
 from warren.xi.factories import ExperienceFactory
-from warren.xi.models import (
-    Experience,
-    Relation,
-)
+from warren.xi.schema import Experience
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Purpose

When bootstraping the project, experience index seeding fails:

```
Seeding the experience index…
Traceback (most recent call last):
  File "/opt/src/seed_experience_index.py", line 11, in <module>
    from warren.xi.models import (
ImportError: cannot import name 'Experience' from 'warren.xi.models' (/app/core/warren/xi/models.py). Did you mean: 'ExperienceRead'?
```

## Proposal

We recently refactored the `xi` application models for Pydantic and SQLModel and forgot to adapt the seeding script.
