### PR TITLE
🐛(docs) fix Docker image build for MacOS users

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -28,8 +28,8 @@ FROM base as core
 
 COPY --from=builder /usr/local /usr/local
 
-# Create group and user
-RUN addgroup --gid ${DOCKER_GID} docs && \
+# Create group (if not already present) and user
+RUN getent group ${DOCKER_GID} || addgroup --gid ${DOCKER_GID} docs && \
       adduser --uid ${DOCKER_UID} --gid ${DOCKER_GID} --disabled-login docs
 
 USER docs


### PR DESCRIPTION
## Purpose

MacOS users default group ID is `20` (staff). This group often already exists on GNU/Linux distributions, hence we should not enforce its creation if it already exists, or else the `docs` Docker image build fails.

## Proposal

Make group creation optional.
