### PR TITLE
Add plugins documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,23 @@ jobs:
             # Get the longuest line width (ignoring release links)
             test $(cat CHANGELOG.md | grep -Ev "^\[.*\]: https://github.com/openfun" | wc -L) -le 80
 
+  # Check that documentation sources are well formatted
+  lint-docs:
+    docker:
+      - image: node:latest
+        auth:
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASSWORD
+    working_directory: ~/fun
+    steps:
+      - checkout
+      - run:
+          name: Install prettier
+          command: yarn add prettier
+      - run:
+          name: Run prettier over markdown sources
+          command: yarn run prettier -c docs/**/*.md
+
   # Check that renovate configuration file is valid
   check-renovate-configuration:
     docker:
@@ -663,6 +680,12 @@ workflows:
             tags:
               only: /(?!^v).*/
       - lint-changelog:
+          filters:
+            branches:
+              ignore: main
+            tags:
+              only: /.*/
+      - lint-docs:
           filters:
             branches:
               ignore: main

--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,8 @@ lint: ## lint api, app and frontend sources
 lint: \
   lint-api \
   lint-app \
-  lint-frontend
+  lint-frontend \
+  lint-docs
 .PHONY: lint
 
 ### API ###
@@ -373,6 +374,14 @@ docs-deploy: ## build and deploy documentation site for all versions
 	@echo "Deploying docs with version main to gh-pages"
 	@$(MIKE) deploy main
 .PHONY: docs-deploy
+
+lint-docs: ## lint the documentation sources
+	$(COMPOSE_RUN) prettier -c docs/**/*.md
+.PHONY: docs-lint
+
+lint-docs-fix: ## fix linter issues for documentation sources
+	$(COMPOSE_RUN) prettier -w docs/**/*.md
+.PHONY: docs-lint
 
 docs-serve: ## run mkdocs live server for dev docs
 	$(WARREN_DOCS_ENV) $(COMPOSE) up docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,3 +171,8 @@ services:
       - .:/app
       - ~/.gitconfig:/home/docs/.gitconfig
       - ~/.ssh:/home/docs/.ssh
+
+  prettier:
+    image: tmknom/prettier
+    volumes:
+      - .:/work

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,44 +1,56 @@
 # Contributing to Warren
 
-Thank you for considering contributing to Warren! We appreciate your interest and support. This documentation provides guidelines on how to contribute effectively to our project.
+Thank you for considering contributing to Warren! We appreciate your interest
+and support. This documentation provides guidelines on how to contribute
+effectively to our project.
 
 ## Issues
 
-Issues are a valuable way to contribute to Warren. They can include bug reports, feature requests, and general questions or discussions. When creating or interacting with issues, please keep the following in mind:
+Issues are a valuable way to contribute to Warren. They can include bug reports,
+feature requests, and general questions or discussions. When creating or
+interacting with issues, please keep the following in mind:
 
 ### 1. Search for existing issues
 
-Before creating a new issue, search the [existing issues](https://github.com/openfun/warren/issues) to see if your concern has already been raised.
-If you find a related issue, you can add your input or follow the discussion.
-Feel free to engage in discussions, offer help, or provide feedback on existing issues.
-Your input is valuable in shaping the project's future.
+Before creating a new issue, search the
+[existing issues](https://github.com/openfun/warren/issues) to see if your
+concern has already been raised. If you find a related issue, you can add your
+input or follow the discussion. Feel free to engage in discussions, offer help,
+or provide feedback on existing issues. Your input is valuable in shaping the
+project's future.
 
 ### 2. Creating a new issue
 
-Use the provided [issue template](https://github.com/openfun/warren/issues/new/choose) that fits the best to your concern.
-Provide as much information as possible when writing your issue.
-Your issue will be reviewed by a project maintainer and you may be offered to open a PR if you want to contribute to the code.
-If not, and if your issue is relevant, a contributor will apply the changes to the project.
-The issue will then be automatically closed when the PR is merged.
+Use the provided
+[issue template](https://github.com/openfun/warren/issues/new/choose) that fits
+the best to your concern. Provide as much information as possible when writing
+your issue. Your issue will be reviewed by a project maintainer and you may be
+offered to open a PR if you want to contribute to the code. If not, and if your
+issue is relevant, a contributor will apply the changes to the project. The
+issue will then be automatically closed when the PR is merged.
 
-Issues will be closed by project maintainers if they are deemed invalid.
-You can always reopen an issue if you believe it hasn't been adequately addressed.
+Issues will be closed by project maintainers if they are deemed invalid. You can
+always reopen an issue if you believe it hasn't been adequately addressed.
 
 ### 3. Code of conduct in discussion
 
 - Be respectful and considerate when participating in discussions.
-- Avoid using offensive language, and maintain a positive and collaborative tone.
+- Avoid using offensive language, and maintain a positive and collaborative
+  tone.
 - Stay on topic and avoid derailing discussions.
 
 ## Discussions
 
-Discussions in the Warren repository are a place for open-ended conversations, questions, and general community interactions. Here's how to effectively use discussions:
+Discussions in the Warren repository are a place for open-ended conversations,
+questions, and general community interactions. Here's how to effectively use
+discussions:
 
 ### 1. Creating a discussion
 
 - Use a clear and concise title that summarizes the topic.
 - In the description, provide context and details regarding the discussion.
-- Use labels to categorize the discussion (e.g., "question," "general discussion," "announcements," etc.).
+- Use labels to categorize the discussion (e.g., "question," "general
+  discussion," "announcements," etc.).
 
 ### 2. Participating in discussions
 
@@ -48,8 +60,9 @@ Discussions in the Warren repository are a place for open-ended conversations, q
 
 ## Pull Requests (PR)
 
-Contributing to Warren through pull requests is a powerful way to advance the project.
-If you want to make changes or add new features, please follow these steps to submit a PR:
+Contributing to Warren through pull requests is a powerful way to advance the
+project. If you want to make changes or add new features, please follow these
+steps to submit a PR:
 
 ### 1. Fork the repository
 
@@ -57,7 +70,9 @@ Begin by forking Warren project's repository.
 
 ### 2. Clone the fork
 
-Clone the forked repository to your local machine and change the directory to the project folder using the following commands (replace `<your_fork>` with your GitHub username):
+Clone the forked repository to your local machine and change the directory to
+the project folder using the following commands (replace `<your_fork>` with your
+GitHub username):
 
 ```bash
 git clone https://github.com/<your_fork>/warren.git
@@ -74,12 +89,16 @@ git checkout -b your-new-feature
 
 ### 4. Make changes
 
-Implement the changes or additions to the code, ensuring it follows [OpenFUN coding and documentation standards](https://handbook.openfun.fr/python).
+Implement the changes or additions to the code, ensuring it follows
+[OpenFUN coding and documentation standards](https://handbook.openfun.fr/python).
 
-For comprehensive guidance on starting your development journey with Warren and preparing your pull request, please refer to our dedicated tutorials.
+For comprehensive guidance on starting your development journey with Warren and
+preparing your pull request, please refer to our dedicated tutorials.
 
-When committing your changes, please adhere to [OpenFUN commit practices](https://handbook.openfun.fr/git#git-conventions).
-Follow the low granularity commit splitting approach and use commit messages based on the Angular commit message guidelines.
+When committing your changes, please adhere to
+[OpenFUN commit practices](https://handbook.openfun.fr/git#git-conventions).
+Follow the low granularity commit splitting approach and use commit messages
+based on the Angular commit message guidelines.
 
 ### 5. Push changes
 
@@ -91,29 +110,33 @@ git push origin feature/your-new-feature
 
 ### 6. Create a pull request
 
-To initiate a Pull Request (PR), head to Warren project's GitHub repository and click on <kbd>New Pull Request</kbd>.
+To initiate a Pull Request (PR), head to Warren project's GitHub repository and
+click on <kbd>New Pull Request</kbd>.
 
 Set your branch as the source and Warren project's `main` branch as the target.
 
-Provide a clear title for your PR and make use of the provided PR body template to document the changes made by your PR.
-This helps streamline the review process and maintain a well-documented project history.
+Provide a clear title for your PR and make use of the provided PR body template
+to document the changes made by your PR. This helps streamline the review
+process and maintain a well-documented project history.
 
 ### 7. Review and discussion
 
-Warren project maintainers will review your PR.
-Be prepared to make necessary changes or address any feedback.
-Patience during this process is appreciated.
+Warren project maintainers will review your PR. Be prepared to make necessary
+changes or address any feedback. Patience during this process is appreciated.
 
 ### 8. Merge
 
-Once your PR is approved, Warren maintainers will merge your changes into the main project.
-Congratulations, you've successfully contributed to Warren! 🎉
+Once your PR is approved, Warren maintainers will merge your changes into the
+main project. Congratulations, you've successfully contributed to Warren! 🎉
 
 ## Releases
 
-The Warren project has multiple services maintained in a single Git repository (_aka_ a monorepo): each service has its own life cycle with its own releases.
+The Warren project has multiple services maintained in a single Git repository
+(_aka_ a monorepo): each service has its own life cycle with its own releases.
 
-We use Git tags to trigger CI builds of the Warren's artifacts (PyPI/NPM packages and Docker images). To make a new release, depending on the service you are releasing, you need to apply the following Git tag pattern conventions:
+We use Git tags to trigger CI builds of the Warren's artifacts (PyPI/NPM
+packages and Docker images). To make a new release, depending on the service you
+are releasing, you need to apply the following Git tag pattern conventions:
 
 | Type         | Service      | Git tag pattern                      | Example             |
 | ------------ | ------------ | ------------------------------------ | ------------------- |
@@ -122,20 +145,32 @@ We use Git tags to trigger CI builds of the Warren's artifacts (PyPI/NPM package
 |              | APP          | `v[0-9]+.[0-9]+.[0-9]+-app`          | `v1.3.6-app`        |
 | Front-end    | core         | `v[0-9]+.[0-9]+.[0-9]+-ui`           | `v5.1.0-ui`         |
 |              | plugin       | `v[0-9]+.[0-9]+.[0-9]+-ui-<plugin>`  | `v3.22.5-ui-video`  |
-| Distribution | \*           | `v[0-9]+.[0-9]+.[0-9]+`               | `v2.0.0`            |
+| Distribution | \*           | `v[0-9]+.[0-9]+.[0-9]+`              | `v2.0.0`            |
 
 !!! Note "About Warren distributions"
 
-    A Warren **distribution** is considered as a "meta" package corresponding to a consistent combination of services releases that are known to work well together. This pattern will be used to tag Docker images and the documentation.
+    A Warren **distribution** is considered as a "meta" package corresponding
+    to a consistent combination of services releases that are known to work well
+    together. This pattern will be used to tag Docker images and the documentation.
 
 ### Working on a new release
 
-This project follows FUN's standard process to release a new version. We invite you to read our [handbook](https://handbook.openfun.fr/git#releasing-new-software-version) that describes it into details.
+This project follows FUN's standard process to release a new version. We invite
+you to read our
+[handbook](https://handbook.openfun.fr/git#releasing-new-software-version) that
+describes it into details.
 
-To release back-end python packages or the related Docker images, this process can be applied by-the-book. However, front-end packages use [changeset](https://github.com/changesets/changesets) to manage their `CHANGELOG`, version and publication. We will describe how to use it below.
+To release back-end python packages or the related Docker images, this process
+can be applied by-the-book. However, front-end packages use
+[changeset](https://github.com/changesets/changesets) to manage their
+`CHANGELOG`, version and publication. We will describe how to use it below.
 
 #### Using `changeset` for front-end packages
 
-When working a front-end package, if your changes are worth to be mentioned in the package `CHANGELOG`, we invite you to log them using the `bin/changeset add` command.
+When working a front-end package, if your changes are worth to be mentioned in
+the package `CHANGELOG`, we invite you to log them using the `bin/changeset add`
+command.
 
-When you are ready to release a package, use the `bin/changeset version` command to bump the package version and update the `CHANGELOG` accordingly. The CI will be in charge to publish them afterwards upon `main` branch tagging.
+When you are ready to release a package, use the `bin/changeset version` command
+to bump the package version and update the `CHANGELOG` accordingly. The CI will
+be in charge to publish them afterwards upon `main` branch tagging.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,15 +17,21 @@
 2. cacheable indicators calculation,
 3. pluggable execution engines,
 4. calculated indicators exposed _via_ an HTTP API,
-5. [LRS](https://en.wikipedia.org/wiki/Learning_Record_Store) as a primary data source,
+5. [LRS](https://en.wikipedia.org/wiki/Learning_Record_Store) as a primary data
+   source,
 6. high extensibility thanks to a plugin-architecture,
-7. [LTI](https://en.wikipedia.org/wiki/Learning_Tools_Interoperability) dashboards integration.
+7. [LTI](https://en.wikipedia.org/wiki/Learning_Tools_Interoperability)
+   dashboards integration.
 
 Warren also provides:
 
-1. a light-weight implementation of ADLNet's [Experience Index](https://github.com/adlnet/xi-lite) (_aka_ XI), a core-component of the recommended [Total Learning Architecture](https://adlnet.gov/news/2020/01/20/ADL-Initiative-established-a-TLA-Sandbox-project/),
+1. a light-weight implementation of ADLNet's
+   [Experience Index](https://github.com/adlnet/xi-lite) (_aka_ XI), a
+   core-component of the recommended
+   [Total Learning Architecture](https://adlnet.gov/news/2020/01/20/ADL-Initiative-established-a-TLA-Sandbox-project/),
 2. extensible indexers for popular LMSes (Moodle, OpenEdx) to feed the XI.
 
-And finally, Warren also provides **web component** to build reactive, beautiful dashboards :heart_eyes:.
+And finally, Warren also provides **web component** to build reactive, beautiful
+dashboards :heart_eyes:.
 
 ![Video dashboard example](./img/dashboard-video-screen.png)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@
 
 </div>
 
-[Warren](/) is a framework for your learning analytics. Its key features are:
+[Warren](./) is a framework for your learning analytics. Its key features are:
 
 1. a simple Python interface to define indicators,
 2. cacheable indicators calculation,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,78 @@
+# Plugins ecosystem
+
+Warren is extensible by design using a plugins architecture. Warren plugins are
+distributed as [Python packages](https://pypi.org/search/?q=warren) for the API
+service and indicators, or as
+[NPM packages](https://www.npmjs.com/search?q=%40openfun%2Fwarren) for UI
+components. This page intends to list known available plugins for Warren (feel
+free to open a pull request to add your plugin in this list!).
+
+## Plugins registry
+
+### Indicators (API service)
+
+- [Warren video](https://github.com/openfun/warren/tree/main/src/api/plugins/video)
+  :label: : a series of indicators related to Video activity
+
+:label: ― offical plugins (maintained by Warren's core team)
+
+### Dataviz (Front-end / APP service)
+
+- [Warren video](https://github.com/openfun/warren/tree/main/src/frontend/packages/video)
+  :label: : a series of ReactJS component to explore Video activity in your
+  Dashboards.
+
+:label: ― offical plugins (maintained by Warren's core team)
+
+## Create your own plugin for Warren
+
+### API
+
+To make your plugin auto-magically discoverable by Warren, you should declare
+[entry points in your module's package](https://setuptools.pypa.io/en/latest/userguide/entry_point.html).
+Two groups of entry points can be declared depending on what your plugin
+extends:
+
+- `warren.routers`: add new routers to the core API
+- `warren.indicators`: allow to compute indicators from the CLI (see
+  `warren indicator` command documentation)
+
+As an example, the Warren Video plugin implements such entry points in its
+package definition:
+
+```toml
+# pyproject.toml
+
+[project.entry-points."warren.routers"]
+video = "warren_video.api:router"
+
+[project.entry-points."warren.indicators"]
+daily_views = "warren_video.indicators:DailyViews"
+daily_unique_views = "warren_video.indicators:DailyUniqueViews"
+daily_completed_views = "warren_video.indicators:DailyCompletedViews"
+daily_unique_completed_views = "warren_video.indicators:DailyUniqueCompletedViews"
+daily_downloads = "warren_video.indicators:DailyDownloads"
+daily_unique_downloads = "warren_video.indicators:DailyUniqueDownloads"
+```
+
+You can check that your indicators are properly registered using the following
+command:
+
+```bash
+warren indicator list
+```
+
+If only the `warren_video` plugin is installed, the command output looks like:
+
+```
+warren_video.indicators:DailyCompletedViews
+warren_video.indicators:DailyDownloads
+warren_video.indicators:DailyUniqueCompletedViews
+warren_video.indicators:DailyUniqueDownloads
+warren_video.indicators:DailyUniqueViews
+warren_video.indicators:DailyViews
+```
+
+### Front-end
+
+TODO

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,9 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.extra
-  - pymdownx.emoji
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.snippets
   - pymdownx.superfences:
       disable_indented_code_blocks: true
@@ -69,6 +71,7 @@ markdown_extensions:
 
 nav:
   - "Warren": index.md
+  - "Plugins": plugins.md
   - "Contributing": contribute.md
   - "About the project":
       - "Changelog": CHANGELOG.md


### PR DESCRIPTION
## Purpose

The recently introduced `warren indicator` CLI command supposes plugins to be properly declared. We need to start documenting API plugins guidelines.

## Proposal

- [x] format documentation using prettier
- [x] enforce documentation sources linting in the CI with prettier
- [x] document API plugins requirements
