### PR TITLE
Add XI CLI commands

### DIFF
--- a/src/api/core/warren/xi/client.py
+++ b/src/api/core/warren/xi/client.py
@@ -109,7 +109,7 @@ class CRUDExperience(BaseCRUD):
             return None
 
         response.raise_for_status()
-        return ExperienceRead.construct(**response.json())
+        return ExperienceRead(**response.json())
 
     async def update(
         self, object_id: UUID, data: Union[ExperienceUpdate, ExperienceCreate]

--- a/src/api/core/warren/xi/indexers/exceptions.py
+++ b/src/api/core/warren/xi/indexers/exceptions.py
@@ -1,0 +1,5 @@
+"""Warren XI indexers exceptions."""
+
+
+class IndexerQueryException(Exception):
+    """An error occurred while querying the indexer."""


### PR DESCRIPTION
## Purpose

We need a CLI command to (list and) index Moodle courses and content in the Experience Index.

## Proposal

- [x] add `xi list` commands
- [x] add `xi index` commands
- [x] write tests
- [x] add explicit error message for moodle login issues
- [x] ~xi routes should be protected behind authentication~ postponed this in a new PR
