### PR TITLE
💚(circle) change deprecated ubuntu machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
 
   build-docker-app:
     machine:
-      image: ubuntu-2204:2023.07.2
+      image: default
       docker_layer_caching: true
     working_directory: ~/fun
     steps:
@@ -580,7 +580,7 @@ jobs:
   # ---- DockerHub publication job ----
   hub:
     machine:
-      image: ubuntu-2204:2023.07.2
+      image: default
       docker_layer_caching: true
     working_directory: ~/fun
     steps:


### PR DESCRIPTION
## Purpose

CircleCI is deprecating all ubuntu machines to ensure pipelines run on latest versions.

## Proposal

Changing ubuntu machines to `default` (latest stable version). Refer to https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177
