### PR TITLE
🔒️(api) require authentication for xi requests

### DIFF
--- a/src/api/core/pyproject.toml
+++ b/src/api/core/pyproject.toml
@@ -123,6 +123,7 @@ target-version = "py39"
 [tool.ruff.lint.per-file-ignores]
 "*/tests/*" = [
     "S101",
+    "PLR0913", # Too many arguments in function
     "PLR2004",  # Pylint magic-value-comparison
 ]
 

--- a/src/api/core/warren/tests/conftest.py
+++ b/src/api/core/warren/tests/conftest.py
@@ -3,7 +3,7 @@
 # pylint: disable=unused-import
 # ruff: noqa: F401
 
-from .fixtures.app import http_client
+from .fixtures.app import http_auth_client, http_client
 from .fixtures.asynchronous import anyio_backend
 from .fixtures.auth import auth_headers
 from .fixtures.db import (

--- a/src/api/core/warren/tests/fixtures/app.py
+++ b/src/api/core/warren/tests/fixtures/app.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient
 
 from warren.api import app
 from warren.conf import settings
+from warren.utils import forge_lti_token
 
 
 @pytest.fixture
@@ -14,4 +15,19 @@ from warren.conf import settings
 async def http_client() -> AsyncIterator[AsyncClient]:
     """Handle application lifespan while yielding asynchronous HTTP client."""
     async with AsyncClient(app=app, base_url=settings.SERVER_URL) as client:
+        yield client
+
+
+@pytest.fixture
+@pytest.mark.anyio
+async def http_auth_client() -> AsyncIterator[AsyncClient]:
+    """Handle application lifespan while yielding asynchronous auth HTTP client.
+
+    In this case, the client is supposed to be authenticated via LTI.
+    """
+    async with AsyncClient(
+        app=app,
+        base_url=settings.SERVER_URL,
+        headers={"Authorization": f"Bearer {forge_lti_token()}"},
+    ) as client:
         yield client

--- a/src/api/core/warren/tests/fixtures/auth.py
+++ b/src/api/core/warren/tests/fixtures/auth.py
@@ -1,13 +1,8 @@
 """Fixtures for the authorization headers of warren api."""
 
-import datetime
-import uuid
-
 import pytest
-from jose import jwt
 
-from ...conf import settings
-from ...models import LTIToken, LTIUser
+from ...utils import forge_lti_token
 
 
 @pytest.fixture
@@ -30,30 +25,4 @@ def auth_headers() -> dict:
                 assert response.status_code == 200
 
     """
-    lti_user = LTIUser(
-        platform="http://fake-lms.com",
-        course="course-v1:openfun+mathematics101+session01",
-        email="johndoe@example.com",
-        user="johndoe",
-    )
-    timestamp = int(datetime.datetime.now().timestamp())
-    lti_parameters = LTIToken(
-        token_type="lti_access",  # noqa: S106
-        exp=timestamp + 10000,
-        iat=timestamp,
-        jti="",
-        session_id=str(uuid.uuid4()),
-        roles=["instructor"],
-        user=lti_user,
-        locale="fr",
-        resource_link_id="8d5dabc2-6af4-42ac-a29b-97649db4a162",
-        resource_link_description="",
-    )
-
-    token = jwt.encode(
-        lti_parameters.dict(),
-        settings.APP_SIGNING_KEY,
-        algorithm=settings.APP_SIGNING_ALGORITHM,
-    )
-
-    return {"Authorization": f"Bearer {token}"}
+    return {"Authorization": f"Bearer {forge_lti_token()}"}

--- a/src/api/core/warren/tests/fixtures/auth.py
+++ b/src/api/core/warren/tests/fixtures/auth.py
@@ -11,7 +11,7 @@ from ...models import LTIToken, LTIUser
 
 
 @pytest.fixture
-def auth_headers():
+def auth_headers() -> dict:
     """Generate authentication headers with a JWT token.
 
     This fixture generates authentication headers for use in testing scenarios.
@@ -43,7 +43,7 @@ def auth_headers():
         iat=timestamp,
         jti="",
         session_id=str(uuid.uuid4()),
-        roles=["instrucgtor"],
+        roles=["instructor"],
         user=lti_user,
         locale="fr",
         resource_link_id="8d5dabc2-6af4-42ac-a29b-97649db4a162",

--- a/src/api/core/warren/tests/xi/client/test_crud_experience.py
+++ b/src/api/core/warren/tests/xi/client/test_crud_experience.py
@@ -14,10 +14,10 @@ from warren.xi.models import ExperienceCreate, ExperienceRead
 
 
 @pytest.mark.anyio
-async def test_crud_experience_raise_status(http_client: AsyncClient, monkeypatch):
+async def test_crud_experience_raise_status(http_auth_client: AsyncClient, monkeypatch):
     """Test that each operation raises an HTTP error in case of failure."""
     monkeypatch.setattr(CRUDExperience, "_base_url", "/api/v1/experiences")
-    crud_instance = CRUDExperience(client=http_client)
+    crud_instance = CRUDExperience(client=http_auth_client)
 
     class WrongData(BaseModel):
         name: str
@@ -36,10 +36,12 @@ async def test_crud_experience_raise_status(http_client: AsyncClient, monkeypatc
 
 
 @pytest.mark.anyio
-async def test_crud_experience_get_not_found(http_client: AsyncClient, monkeypatch):
+async def test_crud_experience_get_not_found(
+    http_auth_client: AsyncClient, monkeypatch
+):
     """Test getting an unknown experience."""
     monkeypatch.setattr(CRUDExperience, "_base_url", "/api/v1/experiences")
-    crud_instance = CRUDExperience(client=http_client)
+    crud_instance = CRUDExperience(client=http_auth_client)
 
     # Assert 'get' return 'None' without raising any HTTP errors
     response = await crud_instance.get(object_id=uuid.uuid4())
@@ -47,10 +49,10 @@ async def test_crud_experience_get_not_found(http_client: AsyncClient, monkeypat
 
 
 @pytest.mark.anyio
-async def test_crud_experience_read_empty(http_client: AsyncClient, monkeypatch):
+async def test_crud_experience_read_empty(http_auth_client: AsyncClient, monkeypatch):
     """Test reading experiences when no experience has been saved."""
     monkeypatch.setattr(CRUDExperience, "_base_url", "/api/v1/experiences")
-    crud_instance = CRUDExperience(client=http_client)
+    crud_instance = CRUDExperience(client=http_auth_client)
 
     # Assert 'get' return 'None' without raising any HTTP errors
     experiences = await crud_instance.read()
@@ -59,11 +61,11 @@ async def test_crud_experience_read_empty(http_client: AsyncClient, monkeypatch)
 
 @pytest.mark.anyio
 async def test_crud_experience_create_or_update_new(
-    http_client: AsyncClient, db_session: Session, monkeypatch
+    http_auth_client: AsyncClient, db_session: Session, monkeypatch
 ):
     """Test creating an experience using 'create_or_update'."""
     monkeypatch.setattr(CRUDExperience, "_base_url", "/api/v1/experiences")
-    crud_instance = CRUDExperience(client=http_client)
+    crud_instance = CRUDExperience(client=http_auth_client)
 
     # Get random experience data
     data = ExperienceFactory.build_dict()
@@ -83,11 +85,11 @@ async def test_crud_experience_create_or_update_new(
 
 @pytest.mark.anyio
 async def test_crud_experience_create_or_update_existing(
-    http_client: AsyncClient, db_session: Session, monkeypatch
+    http_auth_client: AsyncClient, db_session: Session, monkeypatch
 ):
     """Test updating an experience using 'create_or_update'."""
     monkeypatch.setattr(CRUDExperience, "_base_url", "/api/v1/experiences")
-    crud_instance = CRUDExperience(client=http_client)
+    crud_instance = CRUDExperience(client=http_auth_client)
 
     # Get random experience data
     data = ExperienceFactory.build_dict(exclude={})

--- a/src/api/core/warren/tests/xi/client/test_crud_relation.py
+++ b/src/api/core/warren/tests/xi/client/test_crud_relation.py
@@ -14,10 +14,10 @@ from warren.xi.models import RelationCreate
 
 
 @pytest.mark.anyio
-async def test_crud_relation_raise_status(http_client: AsyncClient, monkeypatch):
+async def test_crud_relation_raise_status(http_auth_client: AsyncClient, monkeypatch):
     """Test that each operation raises an HTTP error in case of failure."""
     monkeypatch.setattr(CRUDRelation, "_base_url", "/api/v1/relations")
-    crud_instance = CRUDRelation(client=http_client)
+    crud_instance = CRUDRelation(client=http_auth_client)
 
     class WrongData(BaseModel):
         name: str
@@ -36,10 +36,10 @@ async def test_crud_relation_raise_status(http_client: AsyncClient, monkeypatch)
 
 
 @pytest.mark.anyio
-async def test_crud_relation_get_not_found(http_client: AsyncClient, monkeypatch):
+async def test_crud_relation_get_not_found(http_auth_client: AsyncClient, monkeypatch):
     """Test getting an unknown relation."""
     monkeypatch.setattr(CRUDRelation, "_base_url", "/api/v1/relations")
-    crud_instance = CRUDRelation(client=http_client)
+    crud_instance = CRUDRelation(client=http_auth_client)
 
     # Assert 'get' return 'None' without raising any HTTP errors
     response = await crud_instance.get(object_id=uuid4())
@@ -47,10 +47,10 @@ async def test_crud_relation_get_not_found(http_client: AsyncClient, monkeypatch
 
 
 @pytest.mark.anyio
-async def test_crud_relation_read_empty(http_client: AsyncClient, monkeypatch):
+async def test_crud_relation_read_empty(http_auth_client: AsyncClient, monkeypatch):
     """Test reading relations when no relation has been saved."""
     monkeypatch.setattr(CRUDRelation, "_base_url", "/api/v1/relations")
-    crud_instance = CRUDRelation(client=http_client)
+    crud_instance = CRUDRelation(client=http_auth_client)
 
     # Assert 'get' return 'None' without raising any HTTP errors
     relations = await crud_instance.read()
@@ -59,11 +59,11 @@ async def test_crud_relation_read_empty(http_client: AsyncClient, monkeypatch):
 
 @pytest.mark.anyio
 async def test_crud_relation_create_bidirectional(
-    http_client: AsyncClient, db_session: Session, monkeypatch
+    http_auth_client: AsyncClient, db_session: Session, monkeypatch
 ):
     """Test creating bidirectional relations."""
     monkeypatch.setattr(CRUDRelation, "_base_url", "/api/v1/relations")
-    crud_instance = CRUDRelation(client=http_client)
+    crud_instance = CRUDRelation(client=http_auth_client)
 
     # Get two inverse relation types
     relation_type = RelationType.HASPART

--- a/src/api/core/warren/utils.py
+++ b/src/api/core/warren/utils.py
@@ -1,6 +1,8 @@
 """Warren utils."""
 
+import datetime
 import logging
+import uuid
 from functools import reduce
 from typing import Callable
 
@@ -11,7 +13,7 @@ from pydantic import ValidationError
 from typing_extensions import Annotated  # python <3.9 compat
 
 from .conf import settings
-from .models import LTIToken
+from .models import LTIToken, LTIUser
 
 logger = logging.getLogger(__name__)
 
@@ -60,3 +62,41 @@ def get_lti_token(token: Annotated[str, Depends(oauth2_scheme)]) -> LTIToken:
         ) from exception
 
     return payload
+
+
+JOHN_DOE_USER = LTIUser(
+    platform="http://fake-lms.com",
+    course="course-v1:openfun+mathematics101+session01",
+    email="johndoe@example.com",
+    user="johndoe",
+)
+
+
+def forge_lti_token(
+    user: LTIUser = JOHN_DOE_USER,
+    roles: tuple = ("instructor",),
+    locale: str = "fr",
+    resource_link_id: str = "",
+    resource_link_description: str = "",
+) -> str:
+    """Forge a LTI token to use for the CLI."""
+    timestamp = int(datetime.datetime.now().timestamp())
+    lti_parameters = LTIToken(
+        token_type="lti_access",  # noqa: S106
+        exp=timestamp + 10000,
+        iat=timestamp,
+        jti="",
+        session_id=str(uuid.uuid4()),
+        roles=roles,
+        user=user,
+        locale=locale,
+        resource_link_id=resource_link_id,
+        resource_link_description=resource_link_description,
+    )
+
+    token = jwt.encode(
+        lti_parameters.dict(),
+        settings.APP_SIGNING_KEY,
+        algorithm=settings.APP_SIGNING_ALGORITHM,
+    )
+    return token

--- a/src/api/core/warren/xi/routers/experiences.py
+++ b/src/api/core/warren/xi/routers/experiences.py
@@ -12,6 +12,8 @@ from typing_extensions import Annotated  # python <3.9 compat
 
 from warren.db import get_session
 from warren.fields import IRI
+from warren.models import LTIToken
+from warren.utils import get_lti_token
 
 from ..enums import AggregationLevel, Structure
 from ..filters import Pagination
@@ -31,8 +33,9 @@ logger = logging.getLogger(__name__)
 
 
 @router.get("/", response_model=List[ExperienceReadSnapshot])
-async def read_experiences(
+async def read_experiences(  # noqa: PLR0913
     pagination: Annotated[Pagination, Depends()],
+    token: Annotated[LTIToken, Depends(get_lti_token)],
     session: Session = Depends(get_session),
     structure: Optional[Structure] = None,
     aggregation_level: Optional[AggregationLevel] = None,
@@ -42,6 +45,7 @@ async def read_experiences(
 
     Args:
         pagination (Pagination): The filters for pagination (offset and limit).
+        token (LTIToken): The LTI token used to authenticate user.
         session (Session, optional): The database session.
         structure (Structure, optional): Filter by experience structure.
         aggregation_level (AggregationLevel, optional): Filter by aggregation level.
@@ -71,12 +75,15 @@ async def read_experiences(
 
 @router.post("/", response_model=UUID)
 async def create_experience(
-    experience: ExperienceCreate, session: Session = Depends(get_session)
+    experience: ExperienceCreate,
+    token: Annotated[LTIToken, Depends(get_lti_token)],
+    session: Session = Depends(get_session),
 ):
     """Create an experience.
 
     Args:
         experience (Experience): The data of the experience to create.
+        token (LTIToken): The LTI token used to authenticate user.
         session (Session, optional): The database session.
 
     Returns:
@@ -109,6 +116,7 @@ async def create_experience(
 async def update_experience(
     experience_id: UUID,
     experience: ExperienceUpdate,
+    token: Annotated[LTIToken, Depends(get_lti_token)],
     session: Session = Depends(get_session),
 ):
     """Update an existing experience by ID.
@@ -116,6 +124,7 @@ async def update_experience(
     Args:
         experience_id (UUID): The unique identifier of the experience to be updated.
         experience (ExperienceUpdate): The data to update the experience with.
+        token (LTIToken): The LTI token used to authenticate user.
         session (Session, optional): The database session.
 
     Returns:
@@ -151,11 +160,16 @@ async def update_experience(
 
 
 @router.get("/{experience_id}", response_model=ExperienceRead)
-async def read_experience(experience_id: UUID, session: Session = Depends(get_session)):
+async def read_experience(
+    experience_id: UUID,
+    token: Annotated[LTIToken, Depends(get_lti_token)],
+    session: Session = Depends(get_session),
+):
     """Retrieve detailed information about an experience.
 
     Args:
         experience_id (UUID): The ID of the experience to retrieve.
+        token (LTIToken): The LTI token used to authenticate user.
         session (Session, optional): The database session.
 
     Returns:

--- a/src/api/core/warren/xi/routers/relations.py
+++ b/src/api/core/warren/xi/routers/relations.py
@@ -11,6 +11,8 @@ from sqlmodel import Session, select
 from typing_extensions import Annotated  # python <3.9 compat
 
 from warren.db import get_session
+from warren.models import LTIToken
+from warren.utils import get_lti_token
 
 from ..filters import Pagination
 from ..models import (
@@ -30,12 +32,14 @@ logger = logging.getLogger(__name__)
 @router.get("/", response_model=List[RelationRead])
 async def read_relations(
     pagination: Annotated[Pagination, Depends()],
+    token: Annotated[LTIToken, Depends(get_lti_token)],
     session: Session = Depends(get_session),
 ):
     """Retrieve a list of relations based on query parameters.
 
     Args:
         pagination (Pagination): The filters for pagination (offset and limit).
+        token (LTIToken): The LTI token used to authenticate user.
         session (Session, optional): The database session.
 
     Returns:
@@ -53,12 +57,15 @@ async def read_relations(
 
 @router.post("/", response_model=UUID)
 async def create_relation(
-    relation: RelationCreate, session: Session = Depends(get_session)
+    relation: RelationCreate,
+    token: Annotated[LTIToken, Depends(get_lti_token)],
+    session: Session = Depends(get_session),
 ):
     """Create a relation.
 
     Args:
         relation (Relation): The data of the relation to create.
+        token (LTIToken): The LTI token used to authenticate user.
         session (Session, optional): The database session.
 
     Returns:
@@ -89,13 +96,17 @@ async def create_relation(
 
 @router.put("/{relation_id}", response_model=RelationRead)
 async def update_relation(
-    relation_id: UUID, relation: RelationUpdate, session: Session = Depends(get_session)
+    relation_id: UUID,
+    relation: RelationUpdate,
+    token: Annotated[LTIToken, Depends(get_lti_token)],
+    session: Session = Depends(get_session),
 ):
     """Update an existing relation by ID.
 
     Args:
         relation_id (UUID): The unique identifier of the relation to be updated.
         relation (RelationUpdate): The data to update the relation with.
+        token (LTIToken): The LTI token used to authenticate user.
         session (Session, optional): The database session.
 
     Returns:
@@ -130,11 +141,16 @@ async def update_relation(
 
 
 @router.get("/{relation_id}", response_model=RelationRead)
-async def read_relation(relation_id: UUID, session: Session = Depends(get_session)):
+async def read_relation(
+    relation_id: UUID,
+    token: Annotated[LTIToken, Depends(get_lti_token)],
+    session: Session = Depends(get_session),
+):
     """Retrieve detailed information about a relation.
 
     Args:
         relation_id (IRI): The ID of the relation to retrieve.
+        token (LTIToken): The LTI token used to authenticate user.
         session (Session, optional): The database session.
 
     Returns:


### PR DESCRIPTION
## Purpose

The Experience Index is not supposed to get required with no prior authentication.

## Proposal

- [x] use the same LTI token used for the core indicators API
- [x] forge a token for the XI client
