### PR TITLE
🐛(api) serialize complex models before saving them

### DIFF
--- a/src/api/core/warren/indicators/mixins.py
+++ b/src/api/core/warren/indicators/mixins.py
@@ -136,9 +136,11 @@ class CacheMixin(Cacheable):
             return self._raw_or_pydantic(cache.value)
 
         value = await self.compute()
+        if issubclass(self._compute_annotation, BaseModel):
+            value = value.json()
 
         if cache is None:
-            cache = CacheEntry.model_validate(
+            cache = CacheEntry.parse_obj(
                 CacheEntryCreate(key=self.cache_key, value=value)
             )
             await self.save(cache)


### PR DESCRIPTION
## Purpose

We cannot save complex indicators' result as SQLAlchemy is not able to JSON serialize them before saving.

## Proposal

When using complex embedded Pydantic models for indicator results, we need to serialize them before they can be saved in the database's Cache.
