### PR TITLE
♻️(api) configure root path global variable for alembic configuration

### DIFF
--- a/src/api/core/warren/conf.py
+++ b/src/api/core/warren/conf.py
@@ -43,6 +43,13 @@ class Settings(BaseSettings):
         "actor.openid",
     }
 
+    # API Core Root path
+    # (used at least by everything that is alembic-configuration-related)
+    ROOT_PATH: Path = Path(__file__).parent
+
+    # Alembic
+    ALEMBIC_CFG_PATH: Path = ROOT_PATH / "alembic.ini"
+
     # Security
     ALLOWED_HOSTS: List[str] = [
         "http://localhost:8090",

--- a/src/api/core/warren/migrations/__init__.py
+++ b/src/api/core/warren/migrations/__init__.py
@@ -1,12 +1,11 @@
 """Database migrations helpers."""
 
-from pathlib import Path
-
 from alembic import command
 from alembic.config import Config
 
-ROOT_PATH: Path = Path(__file__).parent.parent
-ALEMBIC_CFG: Config = Config(ROOT_PATH / "alembic.ini")
+from ..conf import settings
+
+ALEMBIC_CFG: Config = Config(settings.ALEMBIC_CFG_PATH)
 
 
 def current(verbose: bool = False):

--- a/src/api/core/warren/tests/fixtures/db.py
+++ b/src/api/core/warren/tests/fixtures/db.py
@@ -20,7 +20,7 @@ def db_engine():
     SQLModel.metadata.create_all(engine)
 
     # Pretend to have all migrations applied
-    alembic_cfg = Config("core/warren/alembic.ini")
+    alembic_cfg = Config(settings.ALEMBIC_CFG_PATH)
     command.stamp(alembic_cfg, "head")
 
     yield engine


### PR DESCRIPTION
## Purpose

Alembic config file is embedded in Warren lib packaging, however, it needs a
relative path to be accessed. Otherwise a redefinition is necessary.

## Proposal

Add a `ROOT_PATH` setting variable for alembic config file relative path
location.
