### PR TITLE
🐛(frontend) add missing CSS files in packages

### DIFF
--- a/src/frontend/packages/core/.eslintignore
+++ b/src/frontend/packages/core/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+tsup.config.ts

--- a/src/frontend/packages/core/package.json
+++ b/src/frontend/packages/core/package.json
@@ -15,12 +15,13 @@
   ],
   "scripts": {
     "lint": "eslint . '**/*.{ts,tsx}'",
-    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "build": "tsup src/index.ts src/index.scss --format cjs,esm --dts",
     "dev": "yarn run build -- --watch"
   },
   "devDependencies": {
     "@types/lodash.clonedeep": "4.5.9",
     "@types/react": "18.2.48",
+    "esbuild-sass-plugin": "3.1.0",
     "eslint": "8.56.0",
     "eslint-config-custom": "*",
     "tsconfig": "*",

--- a/src/frontend/packages/core/tsup.config.ts
+++ b/src/frontend/packages/core/tsup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "tsup";
+import { sassPlugin } from "esbuild-sass-plugin";
+
+export default defineConfig({
+  esbuildPlugins: [sassPlugin()],
+});

--- a/src/frontend/packages/video/.eslintignore
+++ b/src/frontend/packages/video/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+tsup.config.ts

--- a/src/frontend/packages/video/package.json
+++ b/src/frontend/packages/video/package.json
@@ -15,12 +15,13 @@
   ],
   "scripts": {
     "lint": "eslint . '**/*.{ts,tsx}'",
-    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "build": "tsup src/index.ts src/index.scss --format cjs,esm --dts",
     "dev": "yarn run build -- --watch"
   },
   "devDependencies": {
     "@types/lodash.clonedeep": "4.5.9",
     "@types/react": "18.2.47",
+    "esbuild-sass-plugin": "3.1.0",
     "eslint": "8.56.0",
     "eslint-config-custom": "*",
     "tsconfig": "*",

--- a/src/frontend/packages/video/tsup.config.ts
+++ b/src/frontend/packages/video/tsup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "tsup";
+import { sassPlugin } from "esbuild-sass-plugin";
+
+export default defineConfig({
+  esbuildPlugins: [sassPlugin()],
+});

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -3442,6 +3442,14 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+esbuild-sass-plugin@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/esbuild-sass-plugin/-/esbuild-sass-plugin-3.1.0.tgz#a6d1ed0e0f7ea0366c928009d4d11a80612416e9"
+  integrity sha512-LX/PhMuA7KskPDT8yB10/o3C3fTKVWEzcfzGnGH0wqjZm3FEtm4d6dCxUn+252kuWZAgFOGzGOnBv1FpzClJrA==
+  dependencies:
+    resolve "^1.22.8"
+    sass "^1.71.1"
+
 esbuild@^0.19.2, esbuild@^0.19.3:
   version "0.19.11"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.19.11.tgz#4a02dca031e768b5556606e1b468fe72e3325d96"
@@ -5576,7 +5584,7 @@ resolve-pkg-maps@^1.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
-resolve@^1.10.0:
+resolve@^1.10.0, resolve@^1.22.8:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -5713,6 +5721,15 @@ sass@1.69.7:
   version "1.69.7"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.69.7.tgz#6e7e1c8f51e8162faec3e9619babc7da780af3b7"
   integrity sha512-rzj2soDeZ8wtE2egyLXgOOHQvaC2iosZrkF6v3EUG+tBwEvhqUCzm0VP3k9gHF9LXbSrRhT5SksoI56Iw8NPnQ==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
+sass@^1.71.1:
+  version "1.71.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.71.1.tgz#dfb09c63ce63f89353777bbd4a88c0a38386ee54"
+  integrity sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"


### PR DESCRIPTION
## Purpose

We need to embed Scss compiled styles to frontend packages so that all components can benefit from them.

## Proposal

- [x] integrate the `esbuild-sass-plugin` with `tsup`
