### PR TITLE
🔖(frontend:patch) bump core release to 0.1.1

### DIFF
--- a/src/frontend/packages/core/CHANGELOG.md
+++ b/src/frontend/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfun/warren-core
 
+## 0.1.1
+
+### Patch Changes
+
+- Fix CSS files missing in distributed package
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/frontend/packages/core/package.json
+++ b/src/frontend/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfun/warren-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Warren frontend core elements.",
   "private": false,
   "publishConfig": {

--- a/src/frontend/packages/video/CHANGELOG.md
+++ b/src/frontend/packages/video/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @openfun/warren-video
+
+## 0.0.1
+
+### Patch Changes
+
+- Fix CSS files missing in distributed package
+- Updated dependencies
+  - @openfun/warren-core@0.1.1

--- a/src/frontend/packages/video/package.json
+++ b/src/frontend/packages/video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfun/warren-video",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Warren frontend video elements.",
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
### Patch changes

- Fix CSS files missing in distributed package
