### PR TITLE
🔧(project) fix ruff linter warning

### DIFF
--- a/src/api/core/pyproject.toml
+++ b/src/api/core/pyproject.toml
@@ -99,7 +99,11 @@ testpaths = [
 exclude = [
     "core/warren/migrations/versions",
 ]
-lint.select = [
+# Assume Python 3.9.
+target-version = "py39"
+
+[tool.ruff.lint]
+select = [
     "B",  # flake8-bugbear
     "C4",  # flake8-comprehensions
     "D",  # pydocstyle
@@ -116,9 +120,6 @@ lint.select = [
     "T20", # flake8-print
     "W",  # pycodestyle warning
 ]
-
-# Assume Python 3.9.
-target-version = "py39"
 
 [tool.ruff.lint.per-file-ignores]
 "*/tests/*" = [

--- a/src/app/pyproject.toml
+++ b/src/app/pyproject.toml
@@ -86,6 +86,11 @@ python_files = [
 ]
 
 [tool.ruff]
+exclude = ["apps/*/migrations/*"]
+# Assume Python 3.9.
+target-version = "py39"
+
+[tool.ruff.lint]
 select = [
     "B",  # flake8-bugbear
     "C4",  # flake8-comprehensions
@@ -103,17 +108,13 @@ select = [
     "T20", # flake8-print
     "W",  # pycodestyle warning
 ]
-exclude = ["apps/*/migrations/*"]
 
-# Assume Python 3.9.
-target-version = "py39"
-
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "*/tests/*" = [
     "S101",
     "PLR2004",  # Pylint magic-value-comparison
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 # Use Google-style docstrings.
 convention = "google"


### PR DESCRIPTION
## Purpose

Some options of ruff configurations have been moved under `lint` sections.

## Proposal

The `pyproject.toml` config is adapted to stop raising warnings concerning this
relocation.
See Ruff settings documentation: https://docs.astral.sh/ruff/settings/

