### PR TITLE
🔨(project) fix development view error after a refresh

### DIFF
--- a/src/app/apps/development/views.py
+++ b/src/app/apps/development/views.py
@@ -39,7 +39,7 @@ class DevelopmentLTIView(TemplateView):
         dictionary
             context for template rendering.
         """
-        lti_parameters = Development.LTI_PARAMETERS
+        lti_parameters = Development.LTI_PARAMETERS.copy()
 
         # use the HTTP_REFERER like to be consistent with the LTI passport
         request_url = (


### PR DESCRIPTION
## Purpose

After one refresh, development view returns an error. As we are not copying the
LTI_PARAMETERS dict but simply refering to the object, the LTI_PARAMETERS dict
is also modified, resulting in a different initialization on the next refresh.

## Proposal

Fixing it by copying the dict instead of refering to it.
