### PR TITLE
🐛(frontend) correct breadcrumb trail order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Restrict dashboards access to instructors and administrators
  
+### Fixed
+
+- Fix Breadcrumb trail order to be `organization > course > session`
+
 ## [0.1.0] - 2024-03-04
 
 ### Added

--- a/src/frontend/packages/core/src/components/BreadCrumb/index.tsx
+++ b/src/frontend/packages/core/src/components/BreadCrumb/index.tsx
@@ -20,7 +20,7 @@ export const BreadCrumb: React.FC<BreadCrumbProps> = ({ courseInfo }) => {
   const content = useMemo(
     () =>
       courseInfo &&
-      Object.values(courseInfo).filter(Boolean).reverse().join(" > "),
+      `${courseInfo.organization} > ${courseInfo.course_name}${courseInfo.course_run ? ` > ${courseInfo.course_run}` : ""}`,
     [courseInfo],
   );
   return <div>{content}</div>;


### PR DESCRIPTION
## Purpose

Previously, the order of the breadcrumb trail was ambiguous, displaying:
organization > session > course


## Proposal

Addressing the issue by rearranging it to:
organization > course > session

