### PR TITLE
✨(app) send course id to the frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Send LTI course id to the frontend
+
 ### Changed
 
 - Restrict dashboards access to instructors and administrators
- 
+
 ### Fixed
 
 - Fix Breadcrumb trail order to be `organization > course > session`

--- a/src/app/apps/lti/views.py
+++ b/src/app/apps/lti/views.py
@@ -125,6 +125,12 @@ class LTIRequestView(BaseLTIView, RenderMixin, TokenMixin):
         jwt = self.generate_tokens(lti_request)
         course_info = lti_request.get_course_info()
 
+        course_id = None
+        if lti_request.is_edx_format:
+            course_id = lti_request.get_param("context_id")
+        elif lti_request.is_moodle_format:
+            course_id = lti_request.origin_url
+
         # Rename 'school_name' to a LMS-generic name
         course_info["organization"] = course_info.pop("school_name")
 
@@ -132,6 +138,7 @@ class LTIRequestView(BaseLTIView, RenderMixin, TokenMixin):
             "lti_route": kwargs["selection"] or "demo",
             "context_title": lti_request.context_title,
             "course_info": course_info,
+            "course_id": course_id,
             **jwt,
         }
 

--- a/src/frontend/packages/core/src/types/index.ts
+++ b/src/frontend/packages/core/src/types/index.ts
@@ -14,6 +14,7 @@ export interface AppData {
   refresh: string;
   context_title?: string;
   course_info?: CourseData;
+  course_id?: string;
 }
 
 export interface Routes {


### PR DESCRIPTION
## Purpose

With the latest release of `django-lti-toolbox` (version 1.3.0), we can now add the course id in the app data, passed from the Django view to the frontend.
It will allow us to build dashboards restricted to a particular course.

