### PR TITLE
🐛(front/packages) export types in build package

### DIFF
--- a/src/frontend/.changeset/shaggy-cats-wait.md
+++ b/src/frontend/.changeset/shaggy-cats-wait.md
@@ -1,0 +1,6 @@
+---
+"@openfun/warren-video": patch
+"@openfun/warren-core": patch
+---
+
+Export types in build package

--- a/src/frontend/packages/core/package.json
+++ b/src/frontend/packages/core/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "lint": "eslint . '**/*.{ts,tsx}'",
-    "build": "tsup src/index.ts src/index.scss --format cjs,esm --dts",
+    "build": "tsup src/index.ts src/index.scss --format cjs,esm --dts src/index.ts",
     "dev": "yarn run build -- --watch"
   },
   "devDependencies": {

--- a/src/frontend/packages/video/package.json
+++ b/src/frontend/packages/video/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "lint": "eslint . '**/*.{ts,tsx}'",
-    "build": "tsup src/index.ts src/index.scss --format cjs,esm --dts",
+    "build": "tsup src/index.ts src/index.scss --format cjs,esm --dts src/index.ts",
     "dev": "yarn run build -- --watch"
   },
   "devDependencies": {


### PR DESCRIPTION
## Purpose

The types were missing in all packages build. To fix this issue, the build command in each package.json is modified to specify for the  --dts option the entry to use
See: https://tsup.egoist.dev/#generate-declaration-file


## Proposal

- [x] export types in build package
