### PR TITLE
✨(frontend) add an error boundary wrapper component

### DIFF
--- a/src/frontend/.changeset/stupid-mice-clap.md
+++ b/src/frontend/.changeset/stupid-mice-clap.md
@@ -1,0 +1,5 @@
+---
+"@openfun/warren-core": minor
+---
+
+Add an error boundary wrapper component

--- a/src/frontend/packages/core/package.json
+++ b/src/frontend/packages/core/package.json
@@ -39,6 +39,7 @@
     "echarts-for-react": "3.0.2",
     "lodash.clonedeep": "4.5.0",
     "react": "18.2.0",
+    "react-error-boundary": "4.0.13",
     "react-top-loading-bar": "2.3.1"
   }
 }

--- a/src/frontend/packages/core/src/components/BoundaryScreenError/_index.scss
+++ b/src/frontend/packages/core/src/components/BoundaryScreenError/_index.scss
@@ -1,0 +1,18 @@
+.c__error {
+    height: 30rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+
+    &__title {
+        font-size: 2.5rem;
+        text-align: center;
+        font-weight: 400;
+        margin-bottom: 2rem;
+    }
+
+    &__message {
+        text-align: center;
+    }
+}

--- a/src/frontend/packages/core/src/components/BoundaryScreenError/index.tsx
+++ b/src/frontend/packages/core/src/components/BoundaryScreenError/index.tsx
@@ -1,0 +1,12 @@
+interface BoundaryScreenErrorProps {
+  message: string;
+}
+
+export const BoundaryScreenError = ({ message }: BoundaryScreenErrorProps) => {
+  return (
+    <div className="c__error">
+      <div className="c__error__title">Whoops, something went wrong.</div>
+      <div className="c__error__message">{message}</div>
+    </div>
+  );
+};

--- a/src/frontend/packages/core/src/components/LTI/AppContentLoader/index.tsx
+++ b/src/frontend/packages/core/src/components/LTI/AppContentLoader/index.tsx
@@ -1,11 +1,17 @@
 import React, { useMemo, Suspense, useEffect } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { SelectContent } from "../SelectContent";
 import { useLTIContext } from "../../../hooks";
 import { AppData, Routes } from "../../../types";
+import { BoundaryScreenError } from "../../BoundaryScreenError";
 
 export interface AppContentLoaderProps {
   dataContext: AppData;
   routes: Routes;
+}
+
+function fallbackRender({ error }: { error: Error }) {
+  return <BoundaryScreenError message={error.message} />;
 }
 
 /**
@@ -45,8 +51,10 @@ export const AppContentLoader: React.FC<AppContentLoaderProps> = ({
   );
 
   return (
-    <Suspense fallback={<div>loading</div>}>
-      <Content />
-    </Suspense>
+    <ErrorBoundary fallbackRender={fallbackRender}>
+      <Suspense fallback={<div>loading</div>}>
+        <Content />
+      </Suspense>
+    </ErrorBoundary>
   );
 };

--- a/src/frontend/packages/core/src/index.scss
+++ b/src/frontend/packages/core/src/index.scss
@@ -1,6 +1,7 @@
 
 @forward "components/Layout";
 
+@forward "components/BoundaryScreenError";
 @forward "components/Card";
 @forward "components/Comparison";
 @forward "components/Filters";


### PR DESCRIPTION
## Proposal

Adding an error boundary component that wraps the app content and prevent any errors within that content to cause the entire application to crash.
Instead, it will catch those errors, and display an error message.
This is particularly beneficial in scenarios where no course id has been passed through the LTI context.

![Screenshot from 2024-05-07 11-01-11](https://github.com/openfun/warren/assets/18288083/617ac9f5-f3af-4025-b785-268c34292a8f)
