### PR TITLE
✅(api) use test database in tests

### DIFF
--- a/src/api/core/warren/migrations/__init__.py
+++ b/src/api/core/warren/migrations/__init__.py
@@ -6,6 +6,7 @@ from alembic.config import Config
 from ..conf import settings
 
 ALEMBIC_CFG: Config = Config(settings.ALEMBIC_CFG_PATH)
+ALEMBIC_CFG.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
 
 
 def current(verbose: bool = False):

--- a/src/api/core/warren/migrations/env.py
+++ b/src/api/core/warren/migrations/env.py
@@ -6,7 +6,6 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from sqlmodel import SQLModel
-from warren.conf import settings
 
 # Nota bene: be sure to import all models that need to be migrated here
 from warren.xi.schema import Experience, Relation  # noqa: F401
@@ -21,9 +20,6 @@ config = context.config
 # This line sets up loggers basically.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
-
-# Set Database URL from Warren's configuration
-config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/src/api/core/warren/tests/api/test_health.py
+++ b/src/api/core/warren/tests/api/test_health.py
@@ -5,6 +5,7 @@ from ralph.backends.data.base import DataBackendStatus
 
 from warren.api import health
 from warren.backends import lrs_client
+from warren.db import Session
 
 
 @pytest.mark.anyio
@@ -16,8 +17,9 @@ async def test_api_health_lbheartbeat(http_client):
 
 
 @pytest.mark.anyio
-async def test_api_health_heartbeat(http_client, monkeypatch):
+async def test_api_health_heartbeat(db_session, http_client, monkeypatch):
     """Test the heartbeat healthcheck."""
+    monkeypatch.setattr(Session, "_session", db_session)
 
     async def lrs_ok():
         return DataBackendStatus.OK

--- a/src/api/core/warren/tests/fixtures/db.py
+++ b/src/api/core/warren/tests/fixtures/db.py
@@ -21,6 +21,7 @@ def db_engine():
 
     # Pretend to have all migrations applied
     alembic_cfg = Config(settings.ALEMBIC_CFG_PATH)
+    alembic_cfg.set_main_option("sqlalchemy.url", settings.TEST_DATABASE_URL)
     command.stamp(alembic_cfg, "head")
 
     yield engine

--- a/src/api/core/warren/tests/test_db.py
+++ b/src/api/core/warren/tests/test_db.py
@@ -3,11 +3,12 @@
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session as SASession
 
-from warren.db import is_alive
+from warren.db import Session, is_alive
 
 
-def test_db_is_alive(monkeypatch):
+def test_db_is_alive(db_session, monkeypatch):
     """Test the database is_alive status check."""
+    monkeypatch.setattr(Session, "_session", db_session)
     assert is_alive() is True
 
     def raise_operational_error(*args, **kwargs):


### PR DESCRIPTION
## Purpose

Tests were using the `warren-api` database instead of the test database `test-warren-api`, forcing dev to create the real database.
