### PR TITLE
🔨(api) make migrations with warren cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ migrate-api:  ## run alembic database migrations for the api service
 	@echo "Create api service database…"
 	@$(COMPOSE) exec postgresql bash -c 'psql "postgresql://$${POSTGRES_USER}:$${POSTGRES_PASSWORD}@$(DB_HOST):$(DB_PORT)/postgres" -c "create database \"warren-api\";"' || echo "Duly noted, skipping database creation."
 	@echo "Running migrations for api service…"
-	@bin/alembic upgrade head
+	@bin/warren migration upgrade head
 .PHONY: migrate-api
 
 migrate-app:  ## run django database migrations for the app service

--- a/bin/warren
+++ b/bin/warren
@@ -3,6 +3,7 @@
 declare DOCKER_USER
 DOCKER_USER="$(id -u):$(id -g)"
 
-DOCKER_USER=${DOCKER_USER} docker compose exec \
+DOCKER_USER=${DOCKER_USER} docker compose run \
+  --rm \
   api \
   warren "$@"


### PR DESCRIPTION
## Purpose

In PR #249, the default database URL was removed from the Alembic configuration file to facilitate testing with the test database without performing any migrations on the real database.
However, this change prevented migrations from being executed when using the Alembic binary, causing the bootstrap makefile rule to fail.

## Proposal

Adding the possibility to execute migrations when warren-api is not running.