### PR TITLE
✨(cli) add migration check command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - Send LTI course id to the frontend
+- Add a warren migration check CLI command
 
 ### Changed
 

--- a/src/api/core/warren/cli.py
+++ b/src/api/core/warren/cli.py
@@ -9,6 +9,7 @@ from typing import Optional
 from uuid import UUID
 
 import click
+from alembic.util import CommandError
 from pydantic import BaseModel
 
 from warren import __version__ as warren_version
@@ -40,6 +41,15 @@ def cli():
 @cli.group(name="migration")
 def migration():
     """Database migration commands (alembic wrapper)."""
+
+
+@migration.command()
+def check():
+    """Check database migration."""
+    try:
+        alembic_migrations.check()
+    except CommandError:
+        raise click.ClickException("Target database is not up to date.") from None
 
 
 @migration.command()

--- a/src/api/core/warren/migrations/__init__.py
+++ b/src/api/core/warren/migrations/__init__.py
@@ -9,6 +9,11 @@ ALEMBIC_CFG: Config = Config(settings.ALEMBIC_CFG_PATH)
 ALEMBIC_CFG.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
 
 
+def check():
+    """Check if database has unapplied migrations."""
+    command.check(ALEMBIC_CFG)
+
+
 def current(verbose: bool = False):
     """Get information about the current migration state."""
     command.current(ALEMBIC_CFG, verbose=verbose)


### PR DESCRIPTION
## Purpose

The Warren CLI Alembic wrapper lacked a command to verify if the database has any unapplied migrations.                                                       

## Proposal

This update introduces a migration check command, which will exit with a status of 1 if there are unapplied migrations in the target database.
