### PR TITLE
🔖(minor) prepare 0.2.0 distribution release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+
+## [0.2.0] - 2024-05-21
+
 ### Added
 
 - Send LTI course id to the frontend
@@ -47,5 +50,6 @@ and this project adheres to
 - Encapsulate statements pre-processing in a Mixin class
 - Factorize Video indicators
 
-[unreleased]: https://github.com/openfun/warren/compare/v0.1.0...main
+[unreleased]: https://github.com/openfun/warren/compare/v0.2.0...main
+[0.2.0]: https://github.com/openfun/warren/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/openfun/warren/compare/abae78e...v0.1.0

--- a/src/api/core/warren/__init__.py
+++ b/src/api/core/warren/__init__.py
@@ -1,3 +1,3 @@
 """Warren package."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/app/version.json
+++ b/src/app/version.json
@@ -1,6 +1,6 @@
 {
   "source" : "https://github.com/openfun/warren",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "commit" : "fixme",
   "build"  : "fixme"
 }

--- a/src/app/warren/__init__.py
+++ b/src/app/warren/__init__.py
@@ -1,3 +1,3 @@
 """Warren app."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
### Added

- Send LTI course id to the frontend
- Add a warren migration check CLI command

### Changed

- Restrict dashboards access to instructors and administrators
- Change cache key to indicator attributes instead of LRS query parameters

### Fixed

- Fix Breadcrumb trail order to be `organization > course > session`
