### PR TITLE
💚(circle) fix issue with mike documentation build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,7 +478,7 @@ jobs:
             echo "DOCS_VERSION: ${DOCS_VERSION}"
             echo "DOCS_ALIAS: ${DOCS_ALIAS}"
             # Build docs
-            ~/.local/bin/mike deploy ${DOCS_VERSION} ${DOCS_ALIAS}
+            ~/.local/bin/mike deploy --update-aliases ${DOCS_VERSION} ${DOCS_ALIAS}
             # Set default doc to point to
             ~/.local/bin/mike set-default dev
             # Push build docs


### PR DESCRIPTION
## Purpose

When generating a versioned documentation locally and preparing for push, mike was encountering an error due to the absence of the --update-aliases option.

## Proposal

Adding the option, ensuring that the latest alias can be correctly updated to the latest version.
