### PR TITLE
🔒️(project) securely pass user and course ids through jwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to
 
 - Remove restricted access to instructors and administrators
 
+### Security
+
+- Pass `course_id`, `user_id` and `roles` through JWT token instead of app
+ context data
+
 ## [0.2.0] - 2024-05-21
 
 ### Added

--- a/src/api/core/warren/models.py
+++ b/src/api/core/warren/models.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from functools import reduce
 from itertools import groupby
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set
 
 import arrow
 from lti_toolbox.launch_params import LTIRole
@@ -241,10 +241,8 @@ class DailyUniqueCounts(BaseModel):
 class LTIUser(BaseModel):
     """Model to represent LTI user data."""
 
-    platform: str
-    course: str
+    id: str
     email: str
-    user: str
 
 
 class LTIToken(BaseModel):
@@ -255,7 +253,9 @@ class LTIToken(BaseModel):
     iat: int
     jti: str
     session_id: str
-    roles: List[Union[LTIRole, str]]
+    consumer_site: str
+    course_id: str
+    roles: List[LTIRole]
     user: LTIUser
     locale: str
     resource_link_id: str

--- a/src/api/core/warren/tests/test_utils.py
+++ b/src/api/core/warren/tests/test_utils.py
@@ -12,7 +12,15 @@ from jose import jwt
 from lti_toolbox.launch_params import LTIRole
 
 from warren.models import LTIToken, LTIUser
-from warren.utils import JOHN_DOE_USER, forge_lti_token, get_lti_token, pipe
+from warren.utils import (
+    JOHN_DOE_USER,
+    forge_lti_token,
+    get_lti_course_id,
+    get_lti_roles,
+    get_lti_token,
+    get_lti_user_id,
+    pipe,
+)
 
 from ..conf import settings
 
@@ -44,10 +52,8 @@ def test_get_lti_token():
 
     # Mock lti parameters
     lti_user = {
-        "platform": "http://fake-lms.com",
-        "course": "course-v1:openfun+mathematics101+session01",
+        "id": "johndoe",
         "email": "johndoe@example.com",
-        "user": "johndoe",
     }
     timestamp = int(datetime.datetime.now().timestamp())
     expected_lti_parameters = {
@@ -58,6 +64,8 @@ def test_get_lti_token():
         "session_id": str(uuid.uuid4()),
         "roles": ["instructor"],
         "user": lti_user,
+        "consumer_site": "http://fake-lms.com",
+        "course_id": "course-v1:openfun+mathematics101+session01",
         "locale": "fr",
         "resource_link_id": "8d5dabc2-6af4-42ac-a29b-97649db4a162",
         "resource_link_description": "",
@@ -82,10 +90,8 @@ def test_get_lti_token_invalid_signature(mock_logger):
 
     # Mock lti parameters
     lti_user = {
-        "platform": "http://fake-lms.com",
-        "course": "course-v1:openfun+mathematics101+session01",
+        "id": "johndoe",
         "email": "johndoe@example.com",
-        "user": "johndoe",
     }
     timestamp = int(datetime.datetime.now().timestamp())
     lti_parameters = {
@@ -96,6 +102,8 @@ def test_get_lti_token_invalid_signature(mock_logger):
         "session_id": str(uuid.uuid4()),
         "roles": ["instructor"],
         "user": lti_user,
+        "platform": "http://fake-lms.com",
+        "course": "course-v1:openfun+mathematics101+session01",
         "locale": "fr",
         "resource_link_id": "8d5dabc2-6af4-42ac-a29b-97649db4a162",
         "resource_link_description": "",
@@ -124,10 +132,8 @@ def test_get_lti_token_expired(mock_logger):
 
     # Mock lti parameters
     lti_user = {
-        "platform": "http://fake-lms.com",
-        "course": "course-v1:openfun+mathematics101+session01",
+        "id": "johndoe",
         "email": "johndoe@example.com",
-        "user": "johndoe",
     }
     timestamp = int(datetime.datetime.now().timestamp())
     lti_parameters = {
@@ -138,6 +144,8 @@ def test_get_lti_token_expired(mock_logger):
         "session_id": str(uuid.uuid4()),
         "roles": ["instructor"],
         "user": lti_user,
+        "consumer_site": "http://fake-lms.com",
+        "course": "course-v1:openfun+mathematics101+session01",
         "locale": "fr",
         "resource_link_id": "8d5dabc2-6af4-42ac-a29b-97649db4a162",
         "resource_link_description": "",
@@ -167,10 +175,8 @@ def test_get_lti_token_wrong_payload(mock_logger):
 
     # Mock lti parameters
     lti_user = {
-        "platform": "http://fake-lms.com",
-        "course": "course-v1:openfun+mathematics101+session01",
+        "id": "johndoe",
         "email": "johndoe@example.com",
-        "user": "johndoe",
     }
     timestamp = int(datetime.datetime.now().timestamp())
     lti_parameters = {
@@ -181,6 +187,8 @@ def test_get_lti_token_wrong_payload(mock_logger):
         "session_id": str(uuid.uuid4()),
         "roles": [LTIRole.INSTRUCTOR, "other-role"],
         "user": lti_user,
+        "consumer_site": "http://fake-lms.com",
+        "course_id": "course-v1:openfun+mathematics101+session01",
         "locale": "fr",
         "resource_link_id": None,  # Resource link id is missing
         "resource_link_description": None,
@@ -201,6 +209,141 @@ def test_get_lti_token_wrong_payload(mock_logger):
     mock_logger.assert_called_with(
         "%s: %s", "An error occurred while validating the token", mock.ANY
     )
+
+
+def test_get_lti_user_id():
+    """Test the get_lti_user_id function."""
+    # Mock signing env variables
+    settings.APP_SIGNING_KEY = "SigningKeyToChange__FOR_TEST_ONLY"
+    settings.APP_SIGNING_ALGORITHM = "HS256"
+
+    # Mock lti parameters
+    lti_user = {
+        "id": "johndoe",
+        "email": "johndoe@example.com",
+    }
+    timestamp = int(datetime.datetime.now().timestamp())
+    expected_lti_parameters = {
+        "token_type": "lti_access",
+        "exp": timestamp + 10000,
+        "iat": timestamp,
+        "jti": "",
+        "session_id": str(uuid.uuid4()),
+        "roles": ["instructor"],
+        "user": lti_user,
+        "consumer_site": "http://fake-lms.com",
+        "course_id": "course-v1:openfun+mathematics101+session01",
+        "locale": "fr",
+        "resource_link_id": "8d5dabc2-6af4-42ac-a29b-97649db4a162",
+        "resource_link_description": "",
+    }
+
+    token = jwt.encode(
+        expected_lti_parameters,
+        settings.APP_SIGNING_KEY,
+        algorithm=settings.APP_SIGNING_ALGORITHM,
+    )
+
+    lti_token = LTIToken.parse_obj(
+        jwt.decode(
+            token,
+            settings.APP_SIGNING_KEY,
+            algorithms=[settings.APP_SIGNING_ALGORITHM],
+        )
+    )
+
+    # Decode token, verify its signature and validate its payload
+    assert get_lti_user_id(lti_token) == lti_user["id"]
+
+
+def test_get_lti_course_id():
+    """Test the get_lti_course_id function."""
+    # Mock signing env variables
+    settings.APP_SIGNING_KEY = "SigningKeyToChange__FOR_TEST_ONLY"
+    settings.APP_SIGNING_ALGORITHM = "HS256"
+
+    # Mock lti parameters
+    lti_user = {
+        "id": "johndoe",
+        "email": "johndoe@example.com",
+    }
+    course_id = "course-v1:openfun+mathematics101+session01"
+    timestamp = int(datetime.datetime.now().timestamp())
+    expected_lti_parameters = {
+        "token_type": "lti_access",
+        "exp": timestamp + 10000,
+        "iat": timestamp,
+        "jti": "",
+        "session_id": str(uuid.uuid4()),
+        "roles": ["instructor"],
+        "user": lti_user,
+        "consumer_site": "http://fake-lms.com",
+        "course_id": course_id,
+        "locale": "fr",
+        "resource_link_id": "8d5dabc2-6af4-42ac-a29b-97649db4a162",
+        "resource_link_description": "",
+    }
+
+    token = jwt.encode(
+        expected_lti_parameters,
+        settings.APP_SIGNING_KEY,
+        algorithm=settings.APP_SIGNING_ALGORITHM,
+    )
+
+    lti_token = LTIToken.parse_obj(
+        jwt.decode(
+            token,
+            settings.APP_SIGNING_KEY,
+            algorithms=[settings.APP_SIGNING_ALGORITHM],
+        )
+    )
+    # Decode token, verify its signature and validate its payload
+    assert get_lti_course_id(lti_token) == course_id
+
+
+def test_get_lti_roles():
+    """Test the get_lti_roles function."""
+    # Mock signing env variables
+    settings.APP_SIGNING_KEY = "SigningKeyToChange__FOR_TEST_ONLY"
+    settings.APP_SIGNING_ALGORITHM = "HS256"
+
+    # Mock lti parameters
+    lti_user = {
+        "id": "johndoe",
+        "email": "johndoe@example.com",
+    }
+    timestamp = int(datetime.datetime.now().timestamp())
+    expected_lti_parameters = {
+        "token_type": "lti_access",
+        "exp": timestamp + 10000,
+        "iat": timestamp,
+        "jti": "",
+        "session_id": str(uuid.uuid4()),
+        "roles": ["instructor", "administrator"],
+        "user": lti_user,
+        "consumer_site": "http://fake-lms.com",
+        "course_id": "course-v1:openfun+mathematics101+session01",
+        "locale": "fr",
+        "resource_link_id": "8d5dabc2-6af4-42ac-a29b-97649db4a162",
+        "resource_link_description": "",
+    }
+
+    token = jwt.encode(
+        expected_lti_parameters,
+        settings.APP_SIGNING_KEY,
+        algorithm=settings.APP_SIGNING_ALGORITHM,
+    )
+
+    lti_token = LTIToken.parse_obj(
+        jwt.decode(
+            token,
+            settings.APP_SIGNING_KEY,
+            algorithms=[settings.APP_SIGNING_ALGORITHM],
+        )
+    )
+
+    # Decode token, verify its signature and validate its payload
+    assert get_lti_roles(lti_token) == expected_lti_parameters["roles"]
 
 
 def test_forge_lti_token(monkeypatch):
@@ -224,6 +367,8 @@ def test_forge_lti_token(monkeypatch):
         session_id=str(session_id),
         roles=("instructor",),
         user=JOHN_DOE_USER,
+        consumer_site="http://fake-lms.com",
+        course_id="course-v1:openfun+mathematics101+session01",
         locale="fr",
         resource_link_id="",
         resource_link_description="",
@@ -231,15 +376,15 @@ def test_forge_lti_token(monkeypatch):
 
     # OVerride some parameters
     user = LTIUser(
-        platform="http://my-moodle.com",
-        course="i-am-a-course-key",
+        id="citizen4",
         email="citizen4@my-moodle.com",
-        user="citizen4",
     )
     with freeze_time(now):
         token = forge_lti_token(
             user=user,
             roles=("student",),
+            consumer_site="http://my-moodle.com",
+            course_id="i-am-a-course-key",
             locale="en",
             resource_link_id="foo",
             resource_link_description="this is me",
@@ -252,6 +397,8 @@ def test_forge_lti_token(monkeypatch):
         session_id=str(session_id),
         roles=("student",),
         user=user,
+        consumer_site="http://my-moodle.com",
+        course_id="i-am-a-course-key",
         locale="en",
         resource_link_id="foo",
         resource_link_description="this is me",

--- a/src/api/core/warren/xi/client.py
+++ b/src/api/core/warren/xi/client.py
@@ -270,12 +270,12 @@ class ExperienceIndex(Client):
 
         token = forge_lti_token(
             user=LTIUser(
-                platform="https://fake-lms.com",
-                course="all",
+                id="xi",
                 email="xi@fake-lms.com",
-                user="xi",
             ),
             roles=("administrator",),
+            consumer_site="https://fake-lms.com",
+            course_id="all",
         )
         self._client = AsyncClient(
             base_url=self._url,

--- a/src/app/apps/lti/forms.py
+++ b/src/app/apps/lti/forms.py
@@ -1,9 +1,16 @@
 """Warren LTI app forms."""
 
 from django import forms
-from django.core import signing
-from django.core.exceptions import ValidationError
-from django.utils.translation import gettext_lazy as _
+
+
+class BaseLTIContextForm(forms.Form):
+    """Warren LTI context form.
+
+    This form is used to validate context from LTI request.
+    """
+
+    consumer_site = forms.URLField(required=True)
+    course_id = forms.CharField(required=True)
 
 
 class BaseLTIUserForm(forms.Form):
@@ -12,26 +19,5 @@ class BaseLTIUserForm(forms.Form):
     This form is used to validate user initially authenticated via LTI.
     """
 
-    platform = forms.URLField(required=True)
-    course = forms.CharField(required=True, max_length=100)
-    user = forms.CharField(required=True, max_length=100)
+    id = forms.CharField(required=True, max_length=100)
     email = forms.EmailField(required=True)
-
-
-class SignedLTIUserForm(forms.Form):
-    """A LTI user form with a valid signature."""
-
-    signature = forms.CharField(required=True)
-
-    def get_lti_user(self, signature, max_age=3600):
-        """Get LTI user corresponding to input signature."""
-        return signing.loads(signature, max_age=max_age)
-
-    def clean_signature(self):
-        """Validate input signature."""
-        signature = self.cleaned_data.get("signature")
-        try:
-            self.get_lti_user(signature)
-        except signing.BadSignature as exc:
-            raise ValidationError(_("Request signature is not valid")) from exc
-        return signature

--- a/src/app/apps/lti/tests/test_lti_request.py
+++ b/src/app/apps/lti/tests/test_lti_request.py
@@ -95,6 +95,7 @@ class LTIRequestViewTestCase(TestCase):
             "lti_message_type": "basic-lti-launch-request",
             "lti_version": "LTI-1p0",
             "resource_link_id": "df7",
+            "context_id": "course-v1:openfun+mathematics101+session01",
         }
 
         signed_parameters = sign_parameters(
@@ -112,8 +113,7 @@ class LTIRequestViewTestCase(TestCase):
         mock_logger.assert_called_with(
             "LTI user is not valid: %s",
             {
-                "course": ["Ce champ est obligatoire."],
-                "user": ["Ce champ est obligatoire."],
+                "id": ["Ce champ est obligatoire."],
                 "email": ["Ce champ est obligatoire."],
             },
         )
@@ -243,9 +243,6 @@ class LTIRequestViewTestCase(TestCase):
                 "course_name": "Mathematics 101",
                 "course_run": None,
             },
-        )
-        self.assertEqual(
-            context["course_id"], "http://fake-lms.com/course/view.php?id=1234"
         )
 
         LTIRefreshToken(context["refresh"]).verify()

--- a/src/app/apps/lti/tests/test_lti_select.py
+++ b/src/app/apps/lti/tests/test_lti_select.py
@@ -99,6 +99,7 @@ class LTISelectViewTestCase(TestCase):
             "accept_media_types": "application/vnd.ims.lti.v1.ltilink",
             "accept_presentation_document_targets": "frame,iframe,window",
             "content_item_return_url": "http://testserver/",
+            "context_id": "1",
             "roles": "instructor",
         }
 
@@ -117,8 +118,7 @@ class LTISelectViewTestCase(TestCase):
         mock_logger.assert_called_with(
             "LTI user is not valid: %s",
             {
-                "course": ["Ce champ est obligatoire."],
-                "user": ["Ce champ est obligatoire."],
+                "id": ["Ce champ est obligatoire."],
                 "email": ["Ce champ est obligatoire."],
             },
         )

--- a/src/app/apps/lti/tests/test_token.py
+++ b/src/app/apps/lti/tests/test_token.py
@@ -51,14 +51,21 @@ class LTISelectFormAccessTokenTestCase(TestCase):
                 "roles": "Instructor",
             }
         )
+        lti_context = {
+            "consumer_site": "http://my-moodle.com",
+            "course_id": "http://my-moodle.com/course/1",
+        }
         lti_user = {
-            "user_id": 123,
+            "id": 123,
             "username": "lti_user",
+            "email": "contact@example.com",
         }
         session_id = "session123"
 
         # Create an LTIRefreshToken instance from LTI data
-        refresh_token = LTIRefreshToken.from_lti(lti_request, lti_user, session_id)
+        refresh_token = LTIRefreshToken.from_lti(
+            lti_request, lti_context, lti_user, session_id
+        )
 
         # Assert that the refresh token is an instance of LTIRefreshToken
         self.assertIsInstance(refresh_token, LTIRefreshToken)

--- a/src/app/apps/lti/token.py
+++ b/src/app/apps/lti/token.py
@@ -14,13 +14,17 @@ class LTITokenMixin:
     """
 
     @classmethod
-    def from_lti(cls, lti_request: LTI, lti_user: dict, session_id: str):
+    def from_lti(
+        cls, lti_request: LTI, lti_context: dict, lti_user: dict, session_id: str
+    ):
         """Instantiate a token class and update its payload with LTI data."""
         token = cls()
         token.payload.update(
             {
                 "session_id": session_id,
                 "roles": lti_request.roles,
+                "consumer_site": lti_context.get("consumer_site"),
+                "course_id": lti_context.get("course_id"),
                 "user": lti_user,
                 "locale": lti_request.get_param("launch_presentation_locale"),
                 "resource_link_id": lti_request.get_param("resource_link_id"),


### PR DESCRIPTION
## Purpose

Previously, `course_id` was transmitted to the frontend through app context data.
`user_id` was not transmitted to the frontend.

## Proposal

To be secure, both `course_id` and `user_id` will now be transmitted through the LTI token instead of the app context data.
This change prevents users from altering the course_id or user_id to access unauthorized data.
