### PR TITLE
Decode and store JWT token in frontend

### DIFF
--- a/src/frontend/packages/core/package.json
+++ b/src/frontend/packages/core/package.json
@@ -37,6 +37,7 @@
     "dayjs": "1.11.10",
     "echarts": "5.4.3",
     "echarts-for-react": "3.0.2",
+    "jwt-decode": "4.0.0",
     "lodash.clonedeep": "4.5.0",
     "react": "18.2.0",
     "react-error-boundary": "4.0.13",

--- a/src/frontend/packages/core/src/components/LTI/AppContentLoader/index.tsx
+++ b/src/frontend/packages/core/src/components/LTI/AppContentLoader/index.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo, Suspense, useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { SelectContent } from "../SelectContent";
-import { useLTIContext } from "../../../hooks";
+import { useLTIContext, useJwtContext } from "../../../hooks";
 import { AppData, Routes } from "../../../types";
 import { BoundaryScreenError } from "../../BoundaryScreenError";
+import { decodeJwtLTI } from "../../../utils";
 
 export interface AppContentLoaderProps {
   dataContext: AppData;
@@ -29,9 +30,11 @@ export const AppContentLoader: React.FC<AppContentLoaderProps> = ({
   routes,
 }: AppContentLoaderProps) => {
   const { setAppData } = useLTIContext();
+  const { setDecodedJwt } = useJwtContext();
 
   useEffect(() => {
     setAppData(dataContext);
+    setDecodedJwt(decodeJwtLTI(dataContext.access));
   }, []);
 
   const routesName = useMemo(() => Object.keys(routes), [routes]);

--- a/src/frontend/packages/core/src/contexts/index.ts
+++ b/src/frontend/packages/core/src/contexts/index.ts
@@ -1,2 +1,3 @@
 export * from "./ltiContext";
 export * from "./filtersContext";
+export * from "./jwtContext";

--- a/src/frontend/packages/core/src/contexts/jwtContext.tsx
+++ b/src/frontend/packages/core/src/contexts/jwtContext.tsx
@@ -1,0 +1,23 @@
+import React, {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useMemo,
+  useState,
+} from "react";
+import { DecodedJwtLTI } from "../types";
+
+export interface JwtContextType {
+  decodedJwt: DecodedJwtLTI;
+  setDecodedJwt: Dispatch<SetStateAction<any>>;
+}
+
+export const JwtContext = createContext<JwtContextType | null>(null);
+
+export const JwtProvider: React.FC<{ children: any }> = ({ children }) => {
+  const [decodedJwt, setDecodedJwt] = useState<any>({});
+
+  const value = useMemo(() => ({ decodedJwt, setDecodedJwt }), [decodedJwt]);
+
+  return <JwtContext.Provider value={value}>{children}</JwtContext.Provider>;
+};

--- a/src/frontend/packages/core/src/hooks/index.ts
+++ b/src/frontend/packages/core/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./useFilters";
 export * from "./useLTIContext";
 export * from "./useRefreshToken";
 export * from "./useTokenInterceptor";
+export * from "./useJwtContext";

--- a/src/frontend/packages/core/src/hooks/useJwtContext.ts
+++ b/src/frontend/packages/core/src/hooks/useJwtContext.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { JwtContext, JwtContextType } from "../contexts";
+
+export const useJwtContext = (): JwtContextType => {
+  const value = useContext(JwtContext);
+  if (!value) {
+    throw new Error(`Missing wrapping Provider for Store JwtContextType`);
+  }
+  return value;
+};

--- a/src/frontend/packages/core/src/hooks/useRefreshToken.ts
+++ b/src/frontend/packages/core/src/hooks/useRefreshToken.ts
@@ -1,9 +1,12 @@
 import { AxiosInstance } from "axios";
 import { AppData } from "../types";
+import { decodeJwtLTI } from "../utils";
 import { useLTIContext } from "./useLTIContext";
+import { useJwtContext } from "./useJwtContext";
 
 export const useRefreshToken = (client: AxiosInstance) => {
   const { appData, setAppData } = useLTIContext();
+  const { setDecodedJwt } = useJwtContext();
 
   const refreshAccessToken = async () => {
     const response = await client.post("token/refresh/", {
@@ -17,6 +20,8 @@ export const useRefreshToken = (client: AxiosInstance) => {
       ...prevData,
       access: newAccessToken,
     }));
+    // Decode the new access token as the JWT token
+    setDecodedJwt(decodeJwtLTI(newAccessToken));
 
     return newAccessToken;
   };

--- a/src/frontend/packages/core/src/provider/app.tsx
+++ b/src/frontend/packages/core/src/provider/app.tsx
@@ -3,7 +3,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { CunninghamProvider } from "@openfun/cunningham-react";
 import { queryClient } from "../libs";
-import { FiltersProvider, LTIProvider } from "../contexts";
+import { FiltersProvider, LTIProvider, JwtProvider } from "../contexts";
 
 export type AppProviderProps = {
   children: React.ReactNode;
@@ -26,12 +26,14 @@ export type AppProviderProps = {
 export const AppProvider = ({ children }: AppProviderProps) => (
   <CunninghamProvider>
     <LTIProvider>
-      <FiltersProvider>
-        <QueryClientProvider client={queryClient}>
-          {children}
-          <ReactQueryDevtools initialIsOpen />
-        </QueryClientProvider>
-      </FiltersProvider>
+      <JwtProvider>
+        <FiltersProvider>
+          <QueryClientProvider client={queryClient}>
+            {children}
+            <ReactQueryDevtools initialIsOpen />
+          </QueryClientProvider>
+        </FiltersProvider>
+      </JwtProvider>
     </LTIProvider>
   </CunninghamProvider>
 );

--- a/src/frontend/packages/core/src/types/index.ts
+++ b/src/frontend/packages/core/src/types/index.ts
@@ -21,3 +21,23 @@ export interface AppData {
 export interface Routes {
   [key: string]: React.LazyExoticComponent<() => JSX.Element>;
 }
+
+interface DecodedJwtUserLTI {
+  id: string;
+  email: string;
+}
+
+export interface DecodedJwtLTI {
+  consumer_site: string;
+  course_id: string;
+  exp: number;
+  iat: number;
+  jti: string;
+  locale: string;
+  resource_link_description?: string;
+  resource_link_id: string;
+  roles: Array<string>;
+  session_id: string;
+  token_type: string;
+  user: DecodedJwtUserLTI;
+}

--- a/src/frontend/packages/core/src/utils/decodeJwtLTI.ts
+++ b/src/frontend/packages/core/src/utils/decodeJwtLTI.ts
@@ -1,29 +1,10 @@
 import { jwtDecode } from "jwt-decode";
-
-export interface DecodedJwtUserLTI {
-  id: string;
-  email: string;
-}
-
-export interface DecodedJwtLTI {
-  consumer_site: string;
-  course_id: string;
-  exp: number;
-  iat: number;
-  jti: string;
-  locale: string;
-  resource_link_description: string;
-  resource_link_id: string;
-  roles: Array<string>;
-  session_id: string;
-  token_type: string;
-  user: DecodedJwtUserLTI;
-}
+import { DecodedJwtLTI } from "../types";
 
 export const isDecodedJwtLTI = (jwt: unknown): jwt is DecodedJwtLTI => {
   if (jwt && typeof jwt === "object") {
     const courseId = (jwt as DecodedJwtLTI).course_id;
-    const userId = (jwt as DecodedJwtLTI).user?.id;
+    const userId = (jwt as DecodedJwtLTI).user.id;
     const { roles } = jwt as DecodedJwtLTI;
 
     return !!courseId && !!userId && !!roles;

--- a/src/frontend/packages/core/src/utils/index.ts
+++ b/src/frontend/packages/core/src/utils/index.ts
@@ -1,6 +1,6 @@
 export const WARREN_COLOR = "#312783";
 
+export * from "./decodeJwtLTI";
 export * from "./formatDates";
 export * from "./getDefaultDates";
 export * from "./parseDataContext";
-export * from "./jwtDecode";

--- a/src/frontend/packages/core/src/utils/index.ts
+++ b/src/frontend/packages/core/src/utils/index.ts
@@ -3,3 +3,4 @@ export const WARREN_COLOR = "#312783";
 export * from "./formatDates";
 export * from "./getDefaultDates";
 export * from "./parseDataContext";
+export * from "./jwtDecode";

--- a/src/frontend/packages/core/src/utils/jwtDecode.ts
+++ b/src/frontend/packages/core/src/utils/jwtDecode.ts
@@ -1,0 +1,49 @@
+import { jwtDecode } from "jwt-decode";
+
+export interface DecodedJwtUserLTI {
+  id: string;
+  email: string;
+}
+
+export interface DecodedJwtLTI {
+  consumer_site: string;
+  course_id: string;
+  exp: number;
+  iat: number;
+  jti: string;
+  locale: string;
+  resource_link_description: string;
+  resource_link_id: string;
+  roles: Array<string>;
+  session_id: string;
+  token_type: string;
+  user: DecodedJwtUserLTI;
+}
+
+export const isDecodedJwtLTI = (jwt: unknown): jwt is DecodedJwtLTI => {
+  if (jwt && typeof jwt === "object") {
+    const courseId = (jwt as DecodedJwtLTI).course_id;
+    const userId = (jwt as DecodedJwtLTI).user?.id;
+    const { roles } = jwt as DecodedJwtLTI;
+
+    return !!courseId && !!userId && !!roles;
+  }
+
+  return false;
+};
+
+export const decodeJwtLTI = (jwtToDecode?: string): DecodedJwtLTI => {
+  if (!jwtToDecode) {
+    throw new Error(
+      "Impossible to decode JWT token, there is no jwt to decode.",
+    );
+  }
+
+  const jwt = jwtDecode(jwtToDecode);
+
+  if (isDecodedJwtLTI(jwt)) {
+    return jwt;
+  }
+
+  throw new Error("JWT token is invalid");
+};


### PR DESCRIPTION
## Purpose

Jwt token contains course and user information, that can be accessed after
decoding the token. As a decoding step is time consuming, it is executed once
and the content is available for the whole app.

## Proposal

`decodeJwtLTI` utils is now available in warren-core to decode the JWT token and
use `course_id`, `user` or user `roles` everywhere in the application.
