### PR TITLE
🔖(frontend:minor) bump core release to 0.3.0

### DIFF
--- a/src/frontend/.changeset/stupid-mice-clap.md
+++ b/src/frontend/.changeset/stupid-mice-clap.md
@@ -1,5 +1,0 @@
----
-"@openfun/warren-core": minor
----
-
-Add an error boundary wrapper component

--- a/src/frontend/packages/core/CHANGELOG.md
+++ b/src/frontend/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfun/warren-core
 
+## 0.3.0
+
+### Minor Changes
+
+- Add a context to pass data of decoded jwt through the app components
+- Add an error boundary wrapper component
+
 ## 0.1.2
 
 ### Patch Changes

--- a/src/frontend/packages/core/package.json
+++ b/src/frontend/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfun/warren-core",
-  "version": "0.1.2",
+  "version": "0.3.0",
   "description": "Warren frontend core elements.",
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
## [0.3.0] @openfun/warren-core

Minor Changes

- Add a context to pass data of decoded jwt through the app components
- Add an error boundary wrapper component

