### PR TITLE
⬆️(project) upgrade django-lti-toolbox to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Upgrade `django-lti-toolbox` to 2.0.0 to be compatible with Moodle instances
+ under a subpath
+
 ## [0.3.2] - 2024-07-03
 
 ### Fixed

--- a/src/api/core/pyproject.toml
+++ b/src/api/core/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "alembic==1.13.1",
     "arrow==1.3.0",
     "click==8.1.7",
-    "django-lti-toolbox==1.3.0",
+    "django-lti-toolbox==2.0.0",
     "fastapi==0.111.0",
     "importlib-metadata==7.2.1",
     "pandas==2.2.2",

--- a/src/app/apps/lti/tests/test_lti_request.py
+++ b/src/app/apps/lti/tests/test_lti_request.py
@@ -23,13 +23,13 @@ class LTIRequestViewTestCase(TestCase):
         """Set up an LTI consumer and passport for the tests."""
         super().setUp()
         self._consumer = LTIConsumerFactory(
-            slug="test_lti", title="test consumer", url="http://fake-lms.com"
+            slug="test_lti", title="test consumer", url="http://fake-lms.com/lms1/"
         )
         self._passport = LTIPassportFactory(
             title="test passport", consumer=self._consumer
         )
 
-    @override_settings(ALLOWED_HOSTS=["fake-lms.com"])
+    @override_settings(ALLOWED_HOSTS=["fake-warren.com"])
     @mock.patch.object(Logger, "debug")
     def test_views_lti_request_invalid_request_type(self, mock_logger):
         """Validate that view fails when the LTI request type is a selection."""
@@ -39,7 +39,7 @@ class LTIRequestViewTestCase(TestCase):
             "lti_version": "LTI-1p0",
             "accept_media_types": "application/vnd.ims.lti.v1.ltilink",
             "accept_presentation_document_targets": "frame,iframe,window",
-            "content_item_return_url": "http://fake-lms.com/",
+            "content_item_return_url": "http://fake-lms.com/lms1/",
             "context_id": "1",
             "user_id": "1",
             "lis_person_contact_email_primary": "contact@example.com",
@@ -47,20 +47,21 @@ class LTIRequestViewTestCase(TestCase):
         }
 
         signed_parameters = sign_parameters(
-            self._passport, lti_parameters, f"http://fake-lms.com{TARGET_URL_PATH}"
+            self._passport,
+            lti_parameters,
+            f"http://fake-warren.com{TARGET_URL_PATH}",
         )
 
         response = self.client.post(
             TARGET_URL_PATH,
             urlencode(signed_parameters),
             content_type=CONTENT_TYPE,
-            HTTP_REFERER="http://fake-lms.com",
-            HTTP_HOST="fake-lms.com",
+            HTTP_HOST="fake-warren.com",
         )
         self.assertEqual(response.status_code, 403)
         mock_logger.assert_called_with("LTI message type is not valid")
 
-    @override_settings(ALLOWED_HOSTS=["fake-lms.com", "wrongserver.com"])
+    @override_settings(ALLOWED_HOSTS=["fake-warren.com", "wrongserver.com"])
     @mock.patch.object(Logger, "info")
     def test_views_lti_request_invalid_signature(self, mock_logger):
         """Validate that view fails when the LTI signature is invalid."""
@@ -71,7 +72,7 @@ class LTIRequestViewTestCase(TestCase):
         }
 
         signed_parameters = sign_parameters(
-            self._passport, lti_parameters, f"http://fake-lms.com{TARGET_URL_PATH}"
+            self._passport, lti_parameters, f"http://fake-warren.com{TARGET_URL_PATH}"
         )
 
         # The POST request is initiated from a distinct host compared to
@@ -80,13 +81,12 @@ class LTIRequestViewTestCase(TestCase):
             TARGET_URL_PATH,
             urlencode(signed_parameters),
             content_type=CONTENT_TYPE,
-            HTTP_REFERER="https://wrongserver",
             HTTP_HOST="wrongserver.com",
         )
         self.assertEqual(response.status_code, 403)
         mock_logger.assert_called_with("Valid signature: %s", False)
 
-    @override_settings(ALLOWED_HOSTS=["fake-lms.com"])
+    @override_settings(ALLOWED_HOSTS=["fake-warren.com"])
     @mock.patch.object(Logger, "debug")
     def test_views_lti_request_invalid_user(self, mock_logger):
         """Validate that view fails when the LTI user is invalid."""
@@ -99,15 +99,14 @@ class LTIRequestViewTestCase(TestCase):
         }
 
         signed_parameters = sign_parameters(
-            self._passport, lti_parameters, f"http://fake-lms.com{TARGET_URL_PATH}"
+            self._passport, lti_parameters, f"http://fake-warren.com{TARGET_URL_PATH}"
         )
 
         response = self.client.post(
             TARGET_URL_PATH,
             urlencode(signed_parameters),
             content_type=CONTENT_TYPE,
-            HTTP_REFERER="http://fake-lms.com",
-            HTTP_HOST="fake-lms.com",
+            HTTP_HOST="fake-warren.com",
         )
         self.assertEqual(response.status_code, 403)
         mock_logger.assert_called_with(
@@ -119,7 +118,7 @@ class LTIRequestViewTestCase(TestCase):
         )
 
     @override_settings(
-        ALLOWED_HOSTS=["fake-lms.com"],
+        ALLOWED_HOSTS=["fake-warren.com"],
         STORAGES={
             "default": {
                 "BACKEND": "django.core.files.storage.FileSystemStorage",
@@ -143,15 +142,14 @@ class LTIRequestViewTestCase(TestCase):
         }
 
         signed_parameters = sign_parameters(
-            self._passport, lti_parameters, f"http://fake-lms.com{TARGET_URL_PATH}"
+            self._passport, lti_parameters, f"http://fake-warren.com{TARGET_URL_PATH}"
         )
 
         response = self.client.post(
             TARGET_URL_PATH,
             urlencode(signed_parameters),
             content_type=CONTENT_TYPE,
-            HTTP_REFERER="http://fake-lms.com",
-            HTTP_HOST="fake-lms.com",
+            HTTP_HOST="fake-warren.com",
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<html>")
@@ -183,7 +181,7 @@ class LTIRequestViewTestCase(TestCase):
         LTIAccessToken(context["access"]).verify()
 
     @override_settings(
-        ALLOWED_HOSTS=["fake-lms.com"],
+        ALLOWED_HOSTS=["fake-warren.com"],
         STORAGES={
             "default": {
                 "BACKEND": "django.core.files.storage.FileSystemStorage",
@@ -209,15 +207,14 @@ class LTIRequestViewTestCase(TestCase):
         }
 
         signed_parameters = sign_parameters(
-            self._passport, lti_parameters, f"http://fake-lms.com{TARGET_URL_PATH}"
+            self._passport, lti_parameters, f"http://fake-warren.com{TARGET_URL_PATH}"
         )
 
         response = self.client.post(
             TARGET_URL_PATH,
             urlencode(signed_parameters),
             content_type=CONTENT_TYPE,
-            HTTP_REFERER="http://fake-lms.com",
-            HTTP_HOST="fake-lms.com",
+            HTTP_HOST="fake-warren.com",
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<html>")

--- a/src/app/pyproject.toml
+++ b/src/app/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "Django==4.2.7",
     "django-configurations==2.5.1",
     "django-cors-headers==4.4.0",
-    "django-lti-toolbox==1.3.0",
+    "django-lti-toolbox==2.0.0",
     "djangorestframework_simplejwt==5.3.1",
     "dockerflow==2024.4.2",
     "gunicorn==22.0.0",


### PR DESCRIPTION
## Purpose

- `django-lti-toolbox` version 2.0.0 rely on the consumer URL instead of the HTTP_REFERER to build the `origin_url`.
It will allow us to have LMS instances under subpath, e.g. `https://lms.example.com/moodle/`\.
- The same URL was used for both the consumer and Warren in tests. Changing it to make it more clear.
