### PR TITLE
Clean project from remaining pylint config and escapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ MANIFEST
 
 # Test & lint
 .coverage
-.pylint.d
 .pytest_cache
 
 # -- Front end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
         DOCKER_USER: ${DOCKER_USER:-1000}
     user: ${DOCKER_USER:-1000}
     image: "${WARREN_APP_IMAGE_NAME:-warren}:${WARREN_APP_IMAGE_TAG:-app-development}"
-    environment:
-      PYLINTHOME: /app/.pylint.d
     env_file:
       - .env
     ports:
@@ -35,8 +33,6 @@ services:
     image: "${WARREN_API_IMAGE_NAME:-warren}:${WARREN_API_IMAGE_TAG:-api-development}"
     env_file:
       - .env
-    environment:
-      PYLINTHOME: /app/.pylint.d
     ports:
       - "${WARREN_API_SERVER_PORT:-8100}:${WARREN_API_SERVER_PORT:-8100}"
     command:

--- a/src/api/.dockerignore
+++ b/src/api/.dockerignore
@@ -37,7 +37,5 @@ Makefile
 .env.dist
 .git
 .gitignore
-.pylint.d
-.pylintrc
 .pytest_cache
 .vscode

--- a/src/api/core/warren/conf.py
+++ b/src/api/core/warren/conf.py
@@ -98,13 +98,11 @@ class Settings(BaseSettings):
             f"{self.API_DB_HOST}/{self.API_TEST_DB_NAME}"
         )
 
-    # pylint: disable=invalid-name
     @property
     def SERVER_URL(self) -> str:
         """Get the full server URL."""
         return f"{self.SERVER_PROTOCOL}://{self.SERVER_HOST}:{self.SERVER_PORT}"
 
-    # pylint: disable=invalid-name
     @property
     def XI_BASE_URL(self) -> str:
         """Get the Experience Index (XI) base URL."""

--- a/src/api/core/warren/tests/conftest.py
+++ b/src/api/core/warren/tests/conftest.py
@@ -1,6 +1,5 @@
 """Module py.test fixtures."""
 
-# pylint: disable=unused-import
 # ruff: noqa: F401
 
 from .fixtures.app import http_auth_client, http_client

--- a/src/api/core/warren/tests/test_fields.py
+++ b/src/api/core/warren/tests/test_fields.py
@@ -16,7 +16,6 @@ from warren.fields import Date, Datetime
 def test_date_field(date):
     """Test the Date warren field."""
 
-    # pylint: disable=missing-class-docstring
     class MyModel(BaseModel):
         saved_at: Date
 
@@ -29,7 +28,6 @@ def test_date_field(date):
 def test_date_field_with_invalid_inputs():
     """Test the Date warren field with invalid inputs."""
 
-    # pylint: disable=missing-class-docstring
     class MyModel(BaseModel):
         saved_at: Date
 
@@ -44,7 +42,6 @@ def test_date_field_with_invalid_inputs():
 def test_datetime_field(date_time):
     """Test the Datetime warren field."""
 
-    # pylint: disable=missing-class-docstring
     class MyModel(BaseModel):
         saved_at: Datetime
 
@@ -57,7 +54,6 @@ def test_datetime_field(date_time):
 def test_datetime_field_with_invalid_inputs():
     """Test the Datetime warren field with invalid inputs."""
 
-    # pylint: disable=missing-class-docstring
     class MyModel(BaseModel):
         saved_at: Datetime
 

--- a/src/api/core/warren/tests/test_filters.py
+++ b/src/api/core/warren/tests/test_filters.py
@@ -13,7 +13,6 @@ from warren.conf import settings
 from warren.filters import BaseQueryFilters, DatetimeRange
 
 
-# pylint: disable=no-member
 def test_datetime_range_model():
     """Test the DatetimeRange model."""
     # Arrow supports various input string formats, let's just test one
@@ -63,7 +62,6 @@ def test_datetime_range_model():
         period.since = arrow.get("2023-01-01T00:00:00+04:00")
 
 
-# pylint: disable=no-member
 def test_datetime_range_model_defaults(monkeypatch):
     """Test the DatetimeRange model defaults."""
     utcnow = arrow.utcnow()

--- a/src/api/plugins/video/tests/conftest.py
+++ b/src/api/plugins/video/tests/conftest.py
@@ -1,6 +1,5 @@
 """Video plugin test fixtures."""
 
-# pylint: disable=unused-import
 # ruff: noqa: F401
 
 import pytest

--- a/src/app/apps/development/views.py
+++ b/src/app/apps/development/views.py
@@ -44,7 +44,6 @@ class DevelopmentLTIRequestView(TemplateView):
             "lti_routes": Development.LTI_ROUTES,
         }
 
-    # pylint: disable=unused-argument
     def post(self, request, *args, **kwargs):
         """Respond to POST request on the refresh button.
 
@@ -174,7 +173,6 @@ class DevelopmentLTISelectView(TemplateView):
             "accept_media_types": "application/vnd.ims.lti.v1.ltilink",
         }
 
-    # pylint: disable=unused-argument
     def post(self, request, *args, **kwargs):
         """Respond to POST request on the refresh button.
 

--- a/src/app/apps/lti/tests/test_lti_config.py
+++ b/src/app/apps/lti/tests/test_lti_config.py
@@ -32,7 +32,7 @@ class LTIConfigViewTestCase(TestCase):
             "@xmlns:lticm": "http://www.imsglobal.org/xsd/imslticm_v1p0",
             "@xmlns:lticp": "http://www.imsglobal.org/xsd/imslticp_v1p0",
             "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-            "@xsi:schemaLocation": "http://www.imsglobal.org/xsd/imslticc_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticc_v1p0.xsd     http://www.imsglobal.org/xsd/imsbasiclti_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0.xsd     http://www.imsglobal.org/xsd/imslticm_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd     http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd",  # noqa: E501 pylint: disable=line-too-long
+            "@xsi:schemaLocation": "http://www.imsglobal.org/xsd/imslticc_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticc_v1p0.xsd     http://www.imsglobal.org/xsd/imsbasiclti_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0.xsd     http://www.imsglobal.org/xsd/imslticm_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd     http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd",  # noqa: E501
         }
 
         for key, expected_value in expected_cartridge_data.items():


### PR DESCRIPTION
## Purpose

ruff has replaced pylint in project's linter however some pieces of configs and
escapes remained.

## Proposal

- remove useless pylint escapes
- remove pylint env variable in docker compose
- remove untracking of pylint files for git and docker

